### PR TITLE
Updated DataSetModel to initialize model attributes directly from the…

### DIFF
--- a/src/main/webapp/js/landing/models/DataSetModel.js
+++ b/src/main/webapp/js/landing/models/DataSetModel.js
@@ -23,7 +23,7 @@ GDP.LANDING.models = GDP.LANDING.models || {};
 			var datasetInfo = (metadata.identificationInfo.length  > 0) ? metadata.identificationInfo[0] : {};
 			result.identifier = this._getCharValue(metadata.fileIdentifier);
 			if (datasetInfo) {
-				result.abstrct = _.has(datasetInfo, 'abstract') ? this._getCharValue(datasetInfo.abstract) : '';
+				result.abstrct = _.has(datasetInfo, 'abstract') ? this._getCharValue(datasetInfo['abstract']) : '';
 				result.title = (_.has(datasetInfo, 'citation') && _.has(datasetInfo.citation, 'title')) ? this._getCharValue(datasetInfo.citation.title) : '';
 				if (_.has(datasetInfo, 'extent') &&
 					(datasetInfo.extent.length > 0) &&
@@ -59,7 +59,6 @@ GDP.LANDING.models = GDP.LANDING.models || {};
 		 *	@prop {String} title - identifying title of data source.
 		 */
 		_getDataSources : function(metadata) {
-			var metadata = this.get('isoMetadata');
 			var getCharValue = this._getCharValue;
 
 			var isOpeNDAP = function(charValue) {
@@ -145,7 +144,7 @@ GDP.LANDING.models = GDP.LANDING.models || {};
 		 */
 		_getDataSetTimeRange : function(metadata) {
 			if (_.has(metadata, 'identificationInfo') && (metadata.identificationInfo.length > 0) &&
-				(_.has(metadata.identificationInfo[0], 'extent')) && 
+				(_.has(metadata.identificationInfo[0], 'extent')) &&
 				(metadata.identificationInfo[0].extent.length > 0) &&
 				(_.has(metadata.identificationInfo[0].extent[0], 'temporalElement')) &&
 				(metadata.identificationInfo[0].extent[0].temporalElement.length > 0)){

--- a/src/main/webapp/js/landing/templates/data_set_dialog.html
+++ b/src/main/webapp/js/landing/templates/data_set_dialog.html
@@ -23,7 +23,7 @@
 <dl>
 	<dt>Time Range</dt>
 	<dd>
-		{{#if timeRange}}{{timeRange.start}} - {{timeRange.end}}</dd>
+		{{#if datasetTimeRange}}{{datasetTimeRange.start}} - {{datasetTimeRange.end}}</dd>
 		{{else}}Not Available
 		{{/if}}
 	</dd>

--- a/src/main/webapp/js/landing/templates/datasource_select.html
+++ b/src/main/webapp/js/landing/templates/datasource_select.html
@@ -1,9 +1,20 @@
-<div class="panel panel-default">
-	<div class="panel-heading">
-		 <h2 class="panel-title">Dataset Selection</h2>
-	</div>
-	<div class="text-center tile-loading-indicator"><i class="fa fa-spin fa-refresh fa-4x"></i></div>
-	<div id="dataset-tile-container" class="panel-body">
+<div class="dataset-select-container">
+	
+	<div class="dataset-tile-panel-div panel panel-default">
+		<div class="panel-heading">
+			 <h2 class="panel-title">Dataset Selection</h2>
+		</div>
+		<div class="panel-body">
+			<div class="dataset-filter-container">
+				<div>
+					<label>Search&nbsp;</label>
+					<input type="text" class="dataset-search-input" />
+				</div>
+			</div>
+			<div class="dataset-tile-container">
+			<div class="text-center tile-loading-indicator"><i class="fa fa-spin fa-refresh fa-4x"></i></div>
+			</div>
+		</div>
 	</div>
 </div>
 <div class="modal" tabindex="-1" role="dialog" aria-labelledby="data-set-modal-dialog-label" aria-hidden="true">

--- a/src/main/webapp/js/landing/views/DataSetDialogView.js
+++ b/src/main/webapp/js/landing/views/DataSetDialogView.js
@@ -22,15 +22,10 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 		 * the contents in the .modal-content element within the passed in el.
 		 */
 		render : function() {
-			var context = this.model.get('csw');
-			context.dataSources = this.model.getDataSources();
-			context.contactInfo = this.model.getContactInfo();
+			var context = this.model.attributes;
 			context.algorithms = GDP.algorithms.get('gdpAlgorithms')[context.identifier];
-			context.timeRange = this.model.getDataSetTimeRange();
-			context.distributionInfo = this.model.getDistributionTransferOptions();
 			var html = this.template(context);
 			this.$el.find('.dataset-dialog-contents').html(html);
-			this.$el.find('.modal-footer').show();
 
 			return this;
 		},
@@ -45,9 +40,7 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 		 */
 		initialize : function(options) {
 			var self = this;
-			this.$el.find('.dataset-dialog-contents').html('');
-			this.$el.find('.dataset-dialog-loading-indicator').show();
-			this.$el.find('.modal-footer').hide();
+			this.$el.find('.dataset-dialog-loading-indicator').hide();
 			this.$el.modal({});
 			options = options || {};
 			if (_.has(options, 'template')) {
@@ -56,33 +49,9 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 			else {
 				this.template = function() { return 'No template specified'; };
 			}
-			var getRecord = $.Deferred();
-			var isoMetadata = self.model.get('isoMetadata');
-			if (_.isEmpty(isoMetadata)) {
-				GDP.cswClient.requestGetRecordById({
-					outputSchema : 'http://www.isotc211.org/2005/gmd',
-					id : this.model.get('csw').identifier
-				}).done(function(response) {
-					self.model.set('isoMetadata', response.records[0]);
-					getRecord.resolve(response.records[0]);
-				}).fail(function(error) {
-					GDP.logger.error('GetRecordsById failed');
-					getRecord.reject(error);
-				});
-			}
-			else {
-				getRecord.resolve(isoMetadata);
-			}
 
 			Backbone.View.prototype.initialize.apply(this, arguments);
-
-			getRecord.done(function(response) {
-				self.render();
-			}).fail(function(error) {
-				self.$el.find('.dataset-dialog-contents').html('Retrieving meta data failed with error: ' + error);
-			}).always(function() {
-				self.$el.find('.dataset-dialog-loading-indicator').hide();
-			});
+			this.render();
 		},
 
 		/*

--- a/src/main/webapp/js/landing/views/DataSetTileView.js
+++ b/src/main/webapp/js/landing/views/DataSetTileView.js
@@ -57,6 +57,10 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 			});
 		},
 
+		/*
+		 * Sets the visibility of the view to isVisible.
+		 * @param {Boolean} isVisible
+		 */
 		setVisibility : function(isVisible) {
 			if (isVisible) {
 				this.$el.show();

--- a/src/main/webapp/js/landing/views/DataSetTileView.js
+++ b/src/main/webapp/js/landing/views/DataSetTileView.js
@@ -28,7 +28,7 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 		 */
 		initialize : function(options) {
 			var bounds;
-			this.context = this.model.attributes.csw;
+			this.context = this.model.attributes;
 			this.$dialogEl = options.dialogEl;
 
 			var baseLayers = [GDP.util.mapUtils.createWorldStreetMapLayer()];

--- a/src/main/webapp/js/landing/views/DataSetTileView.js
+++ b/src/main/webapp/js/landing/views/DataSetTileView.js
@@ -55,6 +55,15 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 				router : this.router,
 				el : this.$dialogEl
 			});
+		},
+
+		setVisibility : function(isVisible) {
+			if (isVisible) {
+				this.$el.show();
+			}
+			else {
+				this.$el.hide();
+			}
 		}
 	});
 }());

--- a/src/main/webapp/js/landing/views/DataSourceSelectionView.js
+++ b/src/main/webapp/js/landing/views/DataSourceSelectionView.js
@@ -35,21 +35,10 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 			getCswRecords.done(function(response) {
 				var dataSetModels = _.chain(response.records)
 					.map(function(record) {
-						return new self.collection.model({
-							csw : {
-								abstrct : record['abstract'][0],
-								bounds : record.bounds,
-								identifier : record.identifier[0].value,
-								modified : record.modified[0],
-								subject : record.subject,
-								title : record.title[0].value,
-								type : record.type[0].value
-							},
-							isoMetadata : {}
-						});
+						return new self.collection.model(record);
 					})
 					.sortBy(function(model) {
-						return model.attributes.csw.title
+						return model.attributes.title
 					})
 					.value();
 				self.dataSetViews = _.map(dataSetModels, function(model) {

--- a/src/main/webapp/js/landing/views/DataSourceSelectionView.js
+++ b/src/main/webapp/js/landing/views/DataSourceSelectionView.js
@@ -69,6 +69,11 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 
 		},
 
+		/*
+		 * For each dataset tile view created by this view, determine if the text in ev is in
+		 * the title or abstract field of the associated model. If so make it visible, if not hide it.
+		 * @param {Jquery event}ev
+		 */
 		filterByText : function(ev) {
 			var text = ev.target.value.toLowerCase();
 			if (text) {

--- a/src/main/webapp/js/landing/views/DataSourceSelectionView.js
+++ b/src/main/webapp/js/landing/views/DataSourceSelectionView.js
@@ -30,7 +30,7 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 
 			GDP.util.BaseView.prototype.initialize.apply(this, arguments);
 
-			this.$dataSetTileContainer = $('#dataset-tile-container');
+			this.$dataSetTileContainer = $('.dataset-tile-container');
 
 			getCswRecords.done(function(response) {
 				var dataSetModels = _.chain(response.records)

--- a/src/main/webapp/js/landing/views/DataSourceSelectionView.js
+++ b/src/main/webapp/js/landing/views/DataSourceSelectionView.js
@@ -1,5 +1,6 @@
 /*jslint browser: true*/
 /*global $*/
+/*global _*/
 
 var GDP = GDP || {};
 
@@ -11,6 +12,10 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 	"use strict";
 
 	GDP.LANDING.views.DataSourceSelectionView = GDP.util.BaseView.extend({
+
+		events : {
+			'change .dataset-search-input' : 'filterByText'
+		},
 
 		/*
 		 * @constructs
@@ -38,7 +43,7 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 						return new self.collection.model(record);
 					})
 					.sortBy(function(model) {
-						return model.attributes.title
+						return model.attributes.title;
 					})
 					.value();
 				self.dataSetViews = _.map(dataSetModels, function(model) {
@@ -62,6 +67,24 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 				self.$el.find('.tile-loading-indicator').hide();
 			});
 
+		},
+
+		filterByText : function(ev) {
+			var text = ev.target.value.toLowerCase();
+			if (text) {
+				_.each(this.dataSetViews, function(view) {
+					var title = view.model.get('title').toLowerCase();
+					var abstrct = view.model.get('abstrct').toLowerCase();
+
+					var isVisible = (title.search(text) !== -1) || (abstrct.search(text) !== -1);
+					view.setVisibility(isVisible);
+				});
+			}
+			else {
+				_.each(this.dataSetViews, function(view) {
+					view.setVisibility(true);
+				});
+			}
 		}
 	});
 }());

--- a/src/main/webapp/js/ogc/csw.js
+++ b/src/main/webapp/js/ogc/csw.js
@@ -9,26 +9,34 @@ GDP.OGC = GDP.OGC || {};
 GDP.OGC.CSW = function (args) {
 	"use strict";
 	args = args || {};
+
+	this.SCHEMA = {
+		ISO_19115 : 'http://www.isotc211.org/2005/gmd',
+		CSW_2_0_2 : 'http://www.opengis.net/cat/csw/2.0.2'
+	};
+
 	this.url = args.url;
 
 	/*
 	 * @param {Object} args
-	 *     @prop {String} outputSchema (optional) - output schema to be used to in the response.
+	 *     @prop {String} outputSchema (optional) - output schema to be used to in the response. Defaults to ISO_19115
 	 *     @prop {Number} maxRecords (optional) - defaults to 1000
+	 *     @prop {String} elementSetName (optional) - defaults to summary
 	 *     @prop {String} title (optional) - Filter by title property if this is set.
 	 * @returns {jquery.Promise} - Resolves when request is successful and return the response object. Rejected
 	 * if the request fails with the error message.
 	 */
 	this.requestGetRecords = function(args) {
-		var outputSchema = args.outputSchema ? args.outputSchema : 'http://www.opengis.net/cat/csw/2.0.2';
+		var outputSchema = args.outputSchema ? args.outputSchema : this.SCHEMA.ISO_19115;
 		var maxRecords = args.maxRecords || 1000;
+		var elementSetName = args.elementSetName || 'full';
 		var title = args.title || '';
 		var deferred = $.Deferred();
 
 		var cswGetRecFormat = new OpenLayers.Format.CSWGetRecords.v2_0_2();
 		var query = {
 			ElementSetName: {
-				value: "full"
+				value: elementSetName
 			}
 		};
 		var getRecRequest;
@@ -65,8 +73,16 @@ GDP.OGC.CSW = function (args) {
 		return deferred.promise();
 	};
 
+	/*
+*
+	 * @param {Object} args
+	 *     @prop {String} outputSchema (optional) - output schema to be used to in the response. Defaults to ISO_19115
+	 *     @prop {String} id - identifier of the record to retrieve.
+	 * @returns {jquery.Promise} - Resolves when request is successful and return the response object. Rejected
+	 * if the request fails with the error message.
+	 */
 	this.requestGetRecordById = function(args) {
-		var outputSchema = args.outputSchema ? args.outputSchema : 'http://www.opengis.net/cat/csw/2.0.2';
+		var outputSchema = args.outputSchema ? args.outputSchema : this.SCHEMA.ISO_19115;
 		var id = args.id;
 		var cswGetRecFormat = new OpenLayers.Format.CSWGetRecords.v2_0_2();
 		var deferred = $.Deferred();

--- a/src/main/webapp/less/gdp_custom.less
+++ b/src/main/webapp/less/gdp_custom.less
@@ -19,6 +19,9 @@
 	.dataset-filter-container {
 		.make-sm-column(2, 0);
 		color : white;
+		input {
+			color: black;
+		}
 		
 	}
 }

--- a/src/main/webapp/less/gdp_custom.less
+++ b/src/main/webapp/less/gdp_custom.less
@@ -1,16 +1,35 @@
 @import "webjars/META-INF/resources/webjars/bootstrap/3.3.4/less/bootstrap.less";
-
+@brand-primary : #345280;
 #banner-area {
 	font-family : Verdana, Arial, Helvetica, sans-serif;
 	font-size : small;
 }
+.jumbotron {
+	.make-row();
+}
+.dataset-tile-panel-div {
+	.make-row();
+	background-color : @brand-primary;
+
+	.dataset-tile-container {
+		.make-sm-column(10, 0);
+		margin-bottom : 0;
+		border-radius : 0;
+	}
+	.dataset-filter-container {
+		.make-sm-column(2, 0);
+		color : white;
+		
+	}
+}
 .tile-loading-indicator {
 	margin-top : 15px;
 }
+
 .dataset-tile-div {
-	.make-sm-column(6, 0);
-	.make-md-column(4, 0);
-	height : 540px;
+	.make-md-column(6, 0);
+	.make-lg-column(4, 0);
+	height : 560px;
 }
 .dataset-tile-div:hover {
 	background-color : lightgray;

--- a/src/test/js/specs/DataSetDialogView_spec.js
+++ b/src/test/js/specs/DataSetDialogView_spec.js
@@ -14,7 +14,7 @@ describe('GDP.LANDING.views.DataSetDialogView', function() {
 		datasetTimeRange : {start : 'now', end: 'then'},
 		distributionInfo : {url : 'fakeserver.com'}
 	};
-	var TEST_ALGORITHMS = {ID1 : ['L1', 'L2'], {ID2 : ['l3']};
+	var TEST_ALGORITHMS = {ID1 : ['L1', 'L2'], ID2 : ['l3']};
 
 	beforeEach(function() {
 		$('body').append('<div class="modal"><div class="modal-dialog"><div class="modal-content"></div></div></div>');

--- a/src/test/js/specs/DataSetDialogView_spec.js
+++ b/src/test/js/specs/DataSetDialogView_spec.js
@@ -4,37 +4,28 @@ describe('GDP.LANDING.views.DataSetDialogView', function() {
 	var testModel;
 	var testView;
 
+	var TEST_DATA = {
+		abstrct : 'Abstract1',
+		bounds : new OpenLayers.Bounds([1, 2, 3, 4]),
+		identifier : 'ID1',
+		title : 'Title1',
+		dataSources : ['DS1', 'DS2'],
+		contactInfo : {name : 'Name1'},
+		datasetTimeRange : {start : 'now', end: 'then'},
+		distributionInfo : {url : 'fakeserver.com'}
+	};
+	var TEST_ALGORITHMS = {ID1 : ['L1', 'L2'], {ID2 : ['l3']};
+
 	beforeEach(function() {
 		$('body').append('<div class="modal"><div class="modal-dialog"><div class="modal-content"></div></div></div>');
 
-		getDeferred = $.Deferred();
-		GDP.cswClient = {
-			requestGetRecordById : jasmine.createSpy('requestGetRecordByIdSpy').andReturn(getDeferred)
-		};
-
 		templateSpy = jasmine.createSpy('templateSpy');
 
-		testModel = new GDP.LANDING.models.DataSetModel({
-			csw : {
-				abstrct : 'Abstract1',
-				bounds : new OpenLayers.Bounds([1, 2, 3, 4]),
-				identifier : 'ID1',
-				modified : 'yes',
-				subject : 'Subject1',
-				title : 'Title1',
-				type : 'value1'
-			},
-			isoMetadata : {}
-		});
-
-		spyOn(testModel, 'getDataSources').andReturn(['DS1', 'DS2']);
-		spyOn(testModel, 'getContactInfo').andReturn({name : 'Name1'});
-		spyOn(testModel, 'getDataSetTimeRange').andReturn({start : 'now', end: 'then'});
-		spyOn(testModel, 'getDistributionTransferOptions').andReturn({url : 'fakeserver.com'});
-		spyOn(testModel, 'set').andCallThrough();
+		testModel = new GDP.LANDING.models.DataSetModel({identificationInfo : []});
+		testModel.set(TEST_DATA);
 
 		GDP.algorithms = {
-			get : jasmine.createSpy('getSpy').andReturn({ID1 : ['L1', 'L2']}, {ID2 : ['l3']})
+			get : jasmine.createSpy('getSpy').andReturn(TEST_ALGORITHMS)
 		};
 		GDP.logger = {
 			error : jasmine.createSpy('logErrorSpy')
@@ -55,43 +46,15 @@ describe('GDP.LANDING.views.DataSetDialogView', function() {
 		$('.modal').remove();
 	});
 
-	it('Expects that a call to GetRecordById is made', function() {
-		expect(GDP.cswClient.requestGetRecordById).toHaveBeenCalled();
-		expect(GDP.cswClient.requestGetRecordById.calls[0].args[0].id).toEqual('ID1');
-	});
-
-	it('Expects that the modal is initialized before GetRecordBydId is resolved', function() {
+	it('Expects that the modal is initialized and rendered is called with the expected attributes', function() {
 		expect($.fn.modal).toHaveBeenCalled();
-	});
-
-	it('Expects that when GetRecordById is resolved, the model is updated and rendered is called', function() {
-		expect(testView.render).not.toHaveBeenCalled();
-		getDeferred.resolve({
-			records : [{fake_data : 'Fake data'}, {fake_data : 'Fake data2'}]
-		});
-		expect(testModel.attributes.isoMetadata).toEqual({fake_data : 'Fake data'});
 		expect(testView.render).toHaveBeenCalled();
-	});
-
-	it('Expects template to be rendered  with the information returned from the model after a successful GetRecordById', function() {
-		var context;
-		getDeferred.resolve({
-			records : [{fake_data : 'Fake data'}, {fake_data : 'Fake data2'}]
-		});
 		expect(templateSpy).toHaveBeenCalled();
-		context = templateSpy.calls[0].args[0];
-		expect(context.dataSources).toEqual(['DS1', 'DS2']);
-		expect(context.contactInfo).toEqual({name : 'Name1'});
-		expect(context.identifier).toEqual('ID1');
-		expect(context.algorithms).toEqual(['L1', 'L2']);
-		expect(context.timeRange).toEqual({start : 'now', end: 'then'});
-		expect(context.distributionInfo).toEqual({url : 'fakeserver.com'});
-	});
-
-	it('Expects a failed GetRecordById call to not render the view or update the model', function() {
-		getDeferred.reject('Unavailable');
-		expect(testView.render).not.toHaveBeenCalled();
-		expect(testModel.set).not.toHaveBeenCalled();
+		var context = templateSpy.calls[0].args[0];
+		expect(testView.render).toHaveBeenCalled();
+		expect(context.abstrct).toEqual(TEST_DATA.abstrct);
+		expect(context.dataSources).toEqual(TEST_DATA.dataSources);
+		expect(context.algorithms).toEqual(TEST_ALGORITHMS[TEST_DATA.identifier]);
 	});
 
 	it('Expects removeDialog to hide the dialog and remove the view', function() {

--- a/src/test/js/specs/DataSetTileView_spec.js
+++ b/src/test/js/specs/DataSetTileView_spec.js
@@ -21,17 +21,15 @@ describe('GDP.LANDING.views.DataSetTileView', function() {
 
 		spyOn(GDP.LANDING.views, 'DataSetDialogView');
 
-		testModel = new GDP.LANDING.models.DataSetModel({
-			csw : {
-				abstrct : 'Abstract1',
-				bounds : new OpenLayers.Bounds([1, 2, 3, 4]),
-				identifier : 'ID1',
-				modified : 'yes',
-				subject : 'Subject1',
-				title : 'Title1',
-				type : 'value1'
-			},
-			isoMetadata : {}
+		testModel = new GDP.LANDING.models.DataSetModel({identificationInfo : []});
+		testModel.set({
+			abstrct : 'Abstract1',
+			bounds : new OpenLayers.Bounds([1, 2, 3, 4]),
+			identifier : 'ID1',
+			modified : 'yes',
+			subject : 'Subject1',
+			title : 'Title1',
+			type : 'value1'
 		});
 
 		$('body').append('<div id="test-dialog"></div>');
@@ -47,8 +45,8 @@ describe('GDP.LANDING.views.DataSetTileView', function() {
 		$('#test-dialog').remove();
 	});
 
-	it('Expects that the template is created using the model\'s csw attribute as the context', function() {
-		expect(templateSpy).toHaveBeenCalledWith(testModel.attributes.csw);
+	it('Expects that the template is created using the model\'s attributes as the context', function() {
+		expect(templateSpy).toHaveBeenCalledWith(testModel.attributes);
 	});
 
 	it('Expects a map to be create with a layer representing the bounds in the model', function() {

--- a/src/test/js/specs/DataSourceSelectionView_spec.js
+++ b/src/test/js/specs/DataSourceSelectionView_spec.js
@@ -35,42 +35,38 @@ describe('GDP.LANDING.views.DataSourceSelectionView', function() {
 		var response = {
 			records : [
 				{
-					abstract : ['Abstract1'],
-					bounds : {},
-					identifier : [{value :'ID1'}],
-					modified :['yes'],
-					subject : 'Subject1',
-					title : [{value : 'Title1'}],
-					type : [{value : 'value1'}]
+					identificationInfo : [
+						{ abstract : {CharacterString : {value : 'Abstract1'}},
+						citation : {title : {CharacterString : {value : 'Title1'}}}}
+					],
+					fileIdentifier : {CharacterString : {value :'ID1'}}
+
 				}, {
-					abstract : ['Abstract2'],
-					bounds : {},
-					identifier : [{value :'ID2'}],
-					modified :['yes'],
-					subject : 'Subject2',
-					title : [{value : 'Title2'}],
-					type : [{value : 'value2'}]
+					identificationInfo : [
+						{ abstract : {CharacterString : {value : 'Abstract2'}},
+						citation : {title : {CharacterString : {value : 'Title2'}}}}
+					],
+					fileIdentifier : {CharacterString : {value :'ID2'}}
 				}, {
-				abstract : ['Abstract3'],
-					bounds : {},
-					identifier : [{value :'ID3'}],
-					modified :['yes'],
-					subject : 'Subject3',
-					title : [{value : 'Title3'}],
-					type : [{value : 'value3'}]
+					identificationInfo : [
+						{ abstract : {CharacterString : {value : 'Abstract3'}},
+						citation : {title : {CharacterString : {value : 'Title3'}}}}
+					],
+					fileIdentifier : {CharacterString : {value :'ID3'}}
 				}
 			]
 		};
 		getDeferred.resolve(response);
 		expect(testView.collection.size()).toBe(3);
-		expect(testView.collection.first().attributes.csw).toEqual({
+		expect(testView.collection.first().attributes).toEqual({
 			abstrct : 'Abstract1',
-			bounds : {},
+			bounds : '',
 			identifier : 'ID1',
-			modified : 'yes',
-			subject : 'Subject1',
 			title : 'Title1',
-			type : 'value1'
+			dataSources : [],
+			contactInfo : [],
+			datasetTimeRange : null,
+			distributionInfo : null
 		});
 		expect(GDP.LANDING.views.DataSetTileView.calls.length).toBe(3);
 		expect(GDP.LANDING.views.DataSetTileView.calls[0].args[0].model).toEqual(testView.collection.first())

--- a/src/test/js/specs/DataSourceSelectionView_spec.js
+++ b/src/test/js/specs/DataSourceSelectionView_spec.js
@@ -5,6 +5,7 @@ describe('GDP.LANDING.views.DataSourceSelectionView', function() {
 	var testView;
 
 	beforeEach(function() {
+		$('body').append('<div class="dataset-tile-container"></div>');
 		getDeferred = $.Deferred();
 		GDP.cswClient = {
 			requestGetRecords : jasmine.createSpy('requestGetRecordsSpy').andReturn(getDeferred.promise())
@@ -15,7 +16,8 @@ describe('GDP.LANDING.views.DataSourceSelectionView', function() {
 			getTemplate : jasmine.createSpy('getTemplateSpy').andReturn(templateSpy)
 		};
 		collection = new GDP.LANDING.models.DataSetCollection();
-		spyOn(GDP.LANDING.views, 'DataSetTileView');
+		spyOn(GDP.LANDING.views.DataSetTileView.prototype, 'initialize');
+		spyOn(GDP.LANDING.views.DataSetTileView.prototype, 'setVisibility');
 
 		GDP.logger = {
 			debug : jasmine.createSpy('debugSpy')
@@ -25,6 +27,10 @@ describe('GDP.LANDING.views.DataSourceSelectionView', function() {
 			template : templateSpy,
 			collection : collection
 		});
+	});
+
+	afterEach(function() {
+		$('.dataset-tile-container').remove();
 	});
 
 	it('Expects that a getRecords request is made', function() {
@@ -68,15 +74,83 @@ describe('GDP.LANDING.views.DataSourceSelectionView', function() {
 			datasetTimeRange : null,
 			distributionInfo : null
 		});
-		expect(GDP.LANDING.views.DataSetTileView.calls.length).toBe(3);
-		expect(GDP.LANDING.views.DataSetTileView.calls[0].args[0].model).toEqual(testView.collection.first())
+		expect(GDP.LANDING.views.DataSetTileView.prototype.initialize.calls.length).toBe(3);
+		expect(GDP.LANDING.views.DataSetTileView.prototype.initialize.calls[0].args[0].model).toEqual(testView.collection.first())
 		expect(testView.dataSetViews.length).toBe(3);
 	});
 
 	it('Expects a failed getRecords call to create no models or views', function() {
 		getDeferred.reject('Unavailable');
 		expect(testView.collection.size()).toBe(0);
-		expect(GDP.LANDING.views.DataSetTileView).not.toHaveBeenCalled();
+		expect(GDP.LANDING.views.DataSetTileView.prototype.initialize).not.toHaveBeenCalled();
 		expect(testView.dataSetViews.length).toBe(0);
 	});
+
+	describe('Tests for filterByText', function() {
+
+		beforeEach(function() {
+			var response = {
+				records : [
+					{
+						identificationInfo : [
+							{ abstract : {CharacterString : {value : 'Abstract1'}},
+							citation : {title : {CharacterString : {value : 'Title1'}}}}
+						],
+						fileIdentifier : {CharacterString : {value :'ID1'}}
+
+					}, {
+						identificationInfo : [
+							{ abstract : {CharacterString : {value : 'Abstract2'}},
+							citation : {title : {CharacterString : {value : 'Title2'}}}}
+						],
+						fileIdentifier : {CharacterString : {value :'ID2'}}
+					}, {
+						identificationInfo : [
+							{ abstract : {CharacterString : {value : 'Abstract3'}},
+							citation : {title : {CharacterString : {value : 'Title3'}}}}
+						],
+						fileIdentifier : {CharacterString : {value :'ID3'}}
+					}
+				]
+			};
+			getDeferred.resolve(response);
+		});
+
+		it('Expects a calling filterByText with an empty value to call setVisibility on each dataSetView', function() {
+			testView.filterByText({target : {value : ''}});
+			expect(GDP.LANDING.views.DataSetTileView.prototype.setVisibility).toHaveBeenCalled();
+			expect(GDP.LANDING.views.DataSetTileView.prototype.setVisibility.calls.length).toBe(3);
+			_.each(GDP.LANDING.views.DataSetTileView.prototype.setVisibility.calls, function(call) {
+				expect(call.args[0]).toBe(true);
+			});
+		});
+
+		it('Expects a call to filterByText with a value to call setVisibility with true on views where the model\'s title or abstract contains the value', function() {
+			testView.filterByText({target : {value : 'Title1'}});
+			var calls = GDP.LANDING.views.DataSetTileView.prototype.setVisibility.calls;
+			expect(calls.length).toBe(3);
+			expect(calls[0].args[0]).toBe(true);
+			expect(calls[1].args[0]).toBe(false);
+			expect(calls[2].args[0]).toBe(false);
+
+			testView.filterByText({target : {value : 'Abstract2'}});
+			calls = GDP.LANDING.views.DataSetTileView.prototype.setVisibility.calls;
+			expect(calls[3].args[0]).toBe(false);
+			expect(calls[4].args[0]).toBe(true);
+			expect(calls[5].args[0]).toBe(false);
+
+			testView.filterByText({target: {value : 'ID'}});
+			calls = GDP.LANDING.views.DataSetTileView.prototype.setVisibility.calls;
+			expect(calls[6].args[0]).toBe(false);
+			expect(calls[7].args[0]).toBe(false);
+			expect(calls[8].args[0]).toBe(false);
+
+			testView.filterByText({target : {value :'Title'}});
+			calls = GDP.LANDING.views.DataSetTileView.prototype.setVisibility.calls;
+			expect(calls[9].args[0]).toBe(true);
+			expect(calls[10].args[0]).toBe(true);
+			expect(calls[11].args[0]).toBe(true);
+		});
+	});
+
 });


### PR DESCRIPTION
… metadata record. Decided to get the data as ISO-19115 so that in the future other catalog services can be used without modifying the code. Then it made sense to directly parse the metadata record into attributes that can be used by the views and templates.

Updated the tests to reflect the new code.