### PR TITLE
Gdp 929

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/config.jsp
+++ b/src/main/webapp/WEB-INF/jsp/config.jsp
@@ -35,7 +35,7 @@
 			"utilityWps" : "<%= baseUrl %>utilityWps",
 			"processWps" : "<%= baseUrl %>processWps",
 			"csw" : "<%= baseUrl %>csw",
-			"catalogwms" : "<%= baseUrl %>catalogwms"
+			"catalogWms" : "<%= baseUrl %>catalogwms"
 		},
 		"serviceEndpoints" : {
 			"geoserver" : "<%= geoserverEndpoint %>"

--- a/src/main/webapp/WEB-INF/jsp/config.jsp
+++ b/src/main/webapp/WEB-INF/jsp/config.jsp
@@ -34,7 +34,8 @@
 			"geoserver" : "<%= baseUrl %>geoserver",
 			"utilityWps" : "<%= baseUrl %>utilityWps",
 			"processWps" : "<%= baseUrl %>processWps",
-			"csw" : "<%= baseUrl %>csw"
+			"csw" : "<%= baseUrl %>csw",
+			"catalogwms" : "<%= baseUrl %>catalogwms"
 		},
 		"serviceEndpoints" : {
 			"geoserver" : "<%= geoserverEndpoint %>"

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -101,6 +101,23 @@
 	</servlet-mapping>
 	
 	<servlet>
+		<servlet-name>CatalogWMSProxyServlet</servlet-name>
+		<servlet-class>gov.usgs.cida.proxy.AlternateProxyServlet</servlet-class>
+		<init-param>
+			<param-name>forward-url-param</param-name>
+			<param-value>gdp.endpoint.catalogwms</param-value>
+		</init-param>
+		<init-param>
+			<param-name>readTimeout</param-name>
+			<param-value>300000</param-value>
+		</init-param>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>CatalogWMSProxyServlet</servlet-name>
+		<url-pattern>/catalogwms/*</url-pattern>
+	</servlet-mapping>
+	
+	<servlet>
         <servlet-name>shapefile-upload-servlet</servlet-name>
         <servlet-class>gov.usgs.cida.geoutils.geoserver.servlet.ShapefileUploadServlet</servlet-class>
         <!--

--- a/src/main/webapp/js/landing/views/DataSetTileView.js
+++ b/src/main/webapp/js/landing/views/DataSetTileView.js
@@ -1,5 +1,6 @@
 /*jslint browser: true*/
 /*global Backbone*/
+/*global OpenLayers*/
 
 var GDP = GDP || {};
 

--- a/src/main/webapp/js/process_client/views/HubSpatialMapView.js
+++ b/src/main/webapp/js/process_client/views/HubSpatialMapView.js
@@ -53,6 +53,30 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 			else {
 				this.map.zoomToExtent(new OpenLayers.Bounds(GDP.config.get('map').extent.conus['3857']), false);
 			}
+			this._addDatasetBoundingBoxLayer();
+		},
+
+		_addDatasetBoundingBoxLayer : function() {
+			var self = this;
+			var dataSetModel = this.model.get('dataSetModel');
+			var dataSourceUrl = this.model.get('dataSourceUrl');
+			var bounds;
+
+			if (dataSetModel.has('identifier') && dataSetModel.has('bounds')) {
+				bounds = dataSetModel.get('bounds');
+				if (dataSourceUrl) {
+					GDP.util.mapUtils.createDataSourceExtentLayer(bounds, dataSetModel.get('identifier'), dataSourceUrl).done(function(layer) {
+						self.boundsLayer = layer;
+						self.map.addLayer(self.boundsLayer);
+					});
+
+				}
+				else {
+					this.boundsLayer = GDP.util.mapUtils.createDataSetExtentLayer(bounds);
+					this.map.addLayer(this.boundsLayer);
+				}
+
+			}
 		}
 	});
 

--- a/src/main/webapp/js/process_client/views/SpatialView.js
+++ b/src/main/webapp/js/process_client/views/SpatialView.js
@@ -668,22 +668,25 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 		},
 
 		_addDatasetBoundingBoxLayer : function() {
+			var self = this;
 			var dataSetModel = this.model.get('dataSetModel');
+			var dataSourceUrl = this.model.get('dataSourceUrl');
 			var bounds;
-			var boundsFeature;
 
-			if (dataSetModel.has('bounds')) {
-				bounds = GDP.util.mapUtils.transformWGS84ToMercator(new OpenLayers.Bounds(dataSetModel.get('bounds').toArray()));
-				boundsFeature = new OpenLayers.Feature.Vector(bounds.toGeometry(), {}, {
-					strokeColor : '#440000',
-					strokeOpacity : 0.2,
-					strokeWidth : 1,
-					fillColor : '#440000',
-					fillOpacity : 0.2
-				});
-				this.boundsLayer = new OpenLayers.Layer.Vector('Dataset extent');
-				this.boundsLayer.addFeatures([boundsFeature]);
-				this.map.addLayer(this.boundsLayer);
+			if (dataSetModel.has('identifier') && dataSetModel.has('bounds')) {
+				bounds = dataSetModel.get('bounds');
+				if (dataSourceUrl) {
+					GDP.util.mapUtils.createDataSourceExtentLayer(bounds, dataSetModel.get('identifier'), dataSourceUrl).done(function(layer) {
+						self.boundsLayer = layer;
+						self.map.addLayer(self.boundsLayer);
+					});
+
+				}
+				else {
+					this.boundsLayer = GDP.util.mapUtils.createDataSetExtentLayer(bounds);
+					this.map.addLayer(this.boundsLayer);
+				}
+
 			}
 		},
 

--- a/src/main/webapp/js/process_client/views/SpatialView.js
+++ b/src/main/webapp/js/process_client/views/SpatialView.js
@@ -668,25 +668,27 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 		},
 
 		_addDatasetBoundingBoxLayer : function() {
-			var self = this;
-			var dataSetModel = this.model.get('dataSetModel');
-			var dataSourceUrl = this.model.get('dataSourceUrl');
-			var bounds;
+			if (!(_.has(this.boundsLayer))) {
+				var self = this;
+				var dataSetModel = this.model.get('dataSetModel');
+				var dataSourceUrl = this.model.get('dataSourceUrl');
+				var bounds;
 
-			if (dataSetModel.has('identifier') && dataSetModel.has('bounds')) {
-				bounds = dataSetModel.get('bounds');
-				if (dataSourceUrl) {
-					GDP.util.mapUtils.createDataSourceExtentLayer(bounds, dataSetModel.get('identifier'), dataSourceUrl).done(function(layer) {
-						self.boundsLayer = layer;
-						self.map.addLayer(self.boundsLayer);
-					});
+				if (dataSetModel.has('identifier') && dataSetModel.has('bounds')) {
+					bounds = dataSetModel.get('bounds');
+					if (dataSourceUrl) {
+						GDP.util.mapUtils.createDataSourceExtentLayer(bounds, dataSetModel.get('identifier'), dataSourceUrl).done(function(layer) {
+							self.boundsLayer = layer;
+							self.map.addLayer(self.boundsLayer);
+						});
+
+					}
+					else {
+						this.boundsLayer = GDP.util.mapUtils.createDataSetExtentLayer(bounds);
+						this.map.addLayer(this.boundsLayer);
+					}
 
 				}
-				else {
-					this.boundsLayer = GDP.util.mapUtils.createDataSetExtentLayer(bounds);
-					this.map.addLayer(this.boundsLayer);
-				}
-
 			}
 		},
 

--- a/src/main/webapp/js/util/mapUtils.js
+++ b/src/main/webapp/js/util/mapUtils.js
@@ -141,6 +141,11 @@ GDP.util.mapUtils = (function() {
 		);
 	};
 
+	/*
+	 * Creates a new layer representing boundingBox which represents a dataset extent.
+	 * @param {OpenLayers.Bounds} boundingBox
+	 * @returns {OpenLayers.Layer.Vector}
+	 */
 	that.createDataSetExtentLayer = function(boundingBox) {
 		var bounds = that.transformWGS84ToMercator(new OpenLayers.Bounds(boundingBox.toArray()));
 		var boundsFeature = new OpenLayers.Feature.Vector(bounds.toGeometry(), {}, {
@@ -156,6 +161,9 @@ GDP.util.mapUtils = (function() {
 	};
 
 	/*
+	 * @param {OpenLayers.Bounds} boundingBox - Extent of the dataset.
+	 * @param {String} datasetId
+	 * @param {String} dataSourceUrl - should be in the dataset represented by datasetId
 	 * @return Jquery.Deferred.promise that when resolved returns the created layer.
 	 */
 	that.createDataSourceExtentLayer = function(boundingBox, datasetId, dataSourceUrl) {
@@ -182,7 +190,7 @@ GDP.util.mapUtils = (function() {
 					layer = that.createDataSetExtentLayer(boundingBox);
 				}
 				else {
-					if (dataSourceUrl.search('dodsC/') == -1) {
+					if (dataSourceUrl.search('dodsC/') === -1) {
 						layer = that.createDataSetExtentLayer(boundingBox);
 					}
 					else {
@@ -196,7 +204,7 @@ GDP.util.mapUtils = (function() {
 								url,
 								{
 									transparent : true,
-									layers : dataSourceLayer.name,
+									layers : dataSourceLayer.name
 								},
 								{
 									opacity : 0.2,

--- a/src/main/webapp/js/util/mapUtils.js
+++ b/src/main/webapp/js/util/mapUtils.js
@@ -168,7 +168,7 @@ GDP.util.mapUtils = (function() {
 	 */
 	that.createDataSourceExtentLayer = function(boundingBox, datasetId, dataSourceUrl) {
 		// First get the WMS getCapabilities for the datasetId
-		var url = GDP.config.get('application').endpoints.catalogwms + '/' + datasetId;
+		var url = GDP.config.get('application').endpoints.catalogWms + '/' + datasetId;
 		var format = new OpenLayers.Format.WMSCapabilities.v1_3_0();
 		var layer;
 		var dataSourceName;

--- a/src/main/webapp/js/util/mapUtils.js
+++ b/src/main/webapp/js/util/mapUtils.js
@@ -141,6 +141,88 @@ GDP.util.mapUtils = (function() {
 		);
 	};
 
+	that.createDataSetExtentLayer = function(boundingBox) {
+		var bounds = that.transformWGS84ToMercator(new OpenLayers.Bounds(boundingBox.toArray()));
+		var boundsFeature = new OpenLayers.Feature.Vector(bounds.toGeometry(), {}, {
+			strokeColor : '#440000',
+			strokeOpacity : 0.2,
+			strokeWidth : 1,
+			fillColor : '#440000',
+			fillOpacity : 0.2
+		});
+		var boundsLayer = new OpenLayers.Layer.Vector('Dataset extent');
+		boundsLayer.addFeatures([boundsFeature]);
+		return boundsLayer;
+	};
+
+	/*
+	 * @return Jquery.Deferred.promise that when resolved returns the created layer.
+	 */
+	that.createDataSourceExtentLayer = function(boundingBox, datasetId, dataSourceUrl) {
+		// First get the WMS getCapabilities for the datasetId
+		var url = GDP.config.get('application').endpoints.catalogwms + '/' + datasetId;
+		var format = new OpenLayers.Format.WMSCapabilities.v1_3_0();
+		var layer;
+		var dataSourceName;
+		var dataSourceLayer;
+
+		var deferred = $.Deferred();
+
+		OpenLayers.Request.GET({
+			url : url,
+			params : {
+				request : 'GetCapabilities',
+				service : 'WMS',
+				version : '1.3.0'
+			},
+			success : function(response) {
+				var respObj = format.read(response.responseXML);
+				if (_.has(respObj, 'error')) {
+					GDP.debug('Unsuccessfully retrieved wms capabilities');
+					layer = that.createDataSetExtentLayer(boundingBox);
+				}
+				else {
+					if (dataSourceUrl.search('dodsC/') == -1) {
+						layer = that.createDataSetExtentLayer(boundingBox);
+					}
+					else {
+						dataSourceName = _.last(dataSourceUrl.split('dodsC/')).replace(/\//g, '_');
+						dataSourceLayer = _.find(respObj.capability.layers, function(layer) {
+							return _.last(layer.name.split(':')).indexOf(dataSourceName) !== -1;
+						});
+						if (dataSourceLayer) {
+							layer = new OpenLayers.Layer.WMS(
+								'Data source extent',
+								url,
+								{
+									transparent : true,
+									layers : dataSourceLayer.name,
+								},
+								{
+									opacity : 0.2,
+									displayInLayerSwitcher : false,
+									visibility : true,
+									isBaseLayer : false,
+									singleTile : true
+								}
+							);
+						}
+						else {
+							layer = that.createDataSetExtentLayer(boundingBox);
+						}
+					}
+				}
+				deferred.resolve(layer);
+			},
+			failure : function(response) {
+				layer = that.createDataSetExtentLayer(boundingBox);
+				deferred.resolve(layer);
+			}
+		});
+
+		return deferred.promise();
+	};
+
 	return that;
 }());
 


### PR DESCRIPTION
Added a layer representing a dataSet/dataSources extent on the map on the spatial page and the map on the hub page. If a dataSource has not yet been specified, then show the extent of the dataset. If it has, do a getCapabilities call to the catalogwms service to determine if a extent layer exists. If not, just continue to use the dataset extent.

Note that if the user comes from the "advanced" route, no extent layer is shown.