### PR TITLE
Gdp 955

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/config.jsp
+++ b/src/main/webapp/WEB-INF/jsp/config.jsp
@@ -31,14 +31,15 @@
 		"development" : "<%= development %>",
 		"maxPolygonsToShowAttributeValues" : <%= maxPolygonsToShowAttributeValues%>,
 		"endpoints" : {
-			"geoserver" : "<%= baseUrl %>geoserver",
+			"wms" : "<%= baseUrl %>geoserver/wms",
+			"wfs" : "<%= baseUrl %>geoserver/wfs",
 			"utilityWps" : "<%= baseUrl %>utilityWps",
 			"processWps" : "<%= baseUrl %>processWps",
 			"csw" : "<%= baseUrl %>csw",
 			"catalogWms" : "<%= baseUrl %>catalogwms"
 		},
 		"serviceEndpoints" : {
-			"geoserver" : "<%= geoserverEndpoint %>"
+			"wfs" : "<%= geoserverEndpoint %>/wfs"
 		}
 	},
 	"process" : {

--- a/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -53,7 +53,7 @@ String baseUrl = props.getProperty("gdp.base.url");
 	var GDP = GDP || {};
 	GDP.BASE_URL = "<%= baseUrl%>";
 	GDP.DEVELOPMENT = "<%= development%>";
-	GDP.incomingMethod = '<%= request.getMethod() %>';
+	GDP.incomingMethod = "<%= request.getMethod() %>";
 	GDP.incomingParams = {
 		<% 
 			Enumeration<String> paramNames = request.getParameterNames();

--- a/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -73,6 +73,6 @@ String baseUrl = props.getProperty("gdp.base.url");
 					}
 				}
 			}
-		 %>
+		%>
 	};
 </script>

--- a/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -1,7 +1,8 @@
 <%@page import="java.io.File"%>
 <%@page import="java.net.URL"%>
 <%@page import="gov.usgs.cida.config.DynamicReadOnlyProperties"%>
-
+<%@page import="org.apache.commons.lang.StringUtils"%>
+<%@page import="java.util.Enumeration"%>
 <%!
 	protected DynamicReadOnlyProperties props = null;
 	{
@@ -52,4 +53,26 @@ String baseUrl = props.getProperty("gdp.base.url");
 	var GDP = GDP || {};
 	GDP.BASE_URL = "<%= baseUrl%>";
 	GDP.DEVELOPMENT = "<%= development%>";
+	GDP.incomingMethod = '<%= request.getMethod() %>';
+	GDP.incomingParams = {
+		<% 
+			Enumeration<String> paramNames = request.getParameterNames();
+			while (paramNames.hasMoreElements()) {
+				String key = paramNames.nextElement();
+				String value = request.getParameter(key);
+				if (StringUtils.isNotBlank(key)) {
+					if (paramNames.hasMoreElements()){
+		%>
+						"<%=key%>" : "<%=value%>",
+		<%
+					}
+					else {
+		%>
+						"<%=key%>" : "<%=value%>"
+		<%						
+					}
+				}
+			}
+		 %>
+	};
 </script>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -4,6 +4,7 @@
 
     <head>
 		<%@include file="/WEB-INF/jsp/head.jsp" %>
+    	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<link rel="stylesheet" type="text/css" href="css/gdp_custom.css">
 	</head>
     <body>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -4,7 +4,7 @@
 
     <head>
 		<%@include file="/WEB-INF/jsp/head.jsp" %>
-    	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<link rel="stylesheet" type="text/css" href="css/gdp_custom.css">
 	</head>
     <body>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -16,10 +16,6 @@
 				</jsp:include>
 			</header>
 
-			<div class="jumbotron">
-				<h1>Welcome to GDP</h1>
-				<div>Here's where to put the latest and greatest information about GDP</div>
-			</div>
 			<div id="home-page-content"></div>
 			
 			<footer class="row">

--- a/src/main/webapp/js/landing/views/DataSetDialogView.js
+++ b/src/main/webapp/js/landing/views/DataSetDialogView.js
@@ -1,5 +1,6 @@
 /*jslint browser: true*/
 /*global Backbone*/
+/*global _*/
 
 var GDP = GDP || {};
 
@@ -14,7 +15,7 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 
 		events : {
 			'click .cancel-btn' : 'removeDialog',
-			'click .process-btn' : 'goToProcessClient'
+			'submit .process-form' : 'goToProcessClient'
 		},
 
 		/*
@@ -25,7 +26,7 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 			var context = this.model.attributes;
 			var html = this.template(context);
 			this.$el.find('.dataset-dialog-contents').html(html);
-
+			this.$el.find('.process-form').attr('action', 'client/catalog/gdp/dataset/' + this.model.get('identifier'));
 			return this;
 		},
 
@@ -64,9 +65,9 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 		/*
 		 * Go to the process_client using the dataset identifier in the url.
 		 */
-		goToProcessClient : function() {
-			window.location.assign('client/catalog/gdp/dataset/' + this.model.get('identifier'));
+		goToProcessClient : function(ev) {
 			this.remove();
+			ev.currentTarget.submit();
 		}
 
 	});

--- a/src/main/webapp/js/landing/views/DataSetDialogView.js
+++ b/src/main/webapp/js/landing/views/DataSetDialogView.js
@@ -66,7 +66,7 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 		 * Go to the process_client using the dataset identifier in the url.
 		 */
 		goToProcessClient : function(ev) {
-			this.remove();
+			this.removeDialog();
 			ev.currentTarget.submit();
 		}
 

--- a/src/main/webapp/js/landing/views/DataSourceSelectionView.js
+++ b/src/main/webapp/js/landing/views/DataSourceSelectionView.js
@@ -161,7 +161,7 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 					};
 				}
 				else {
-					context.default = {
+					context.defaultCaller = {
 						itemId : GDP.incomingParams.item_id,
 						caller : GDP.incomingParams.caller
 					};

--- a/src/main/webapp/js/landing/views/DataSourceSelectionView.js
+++ b/src/main/webapp/js/landing/views/DataSourceSelectionView.js
@@ -50,7 +50,9 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 				.value());
 			this.context = {
 				algorithmFilters : _.keys(this.algorithmFilters),
-				aoiMessageContext : this._getAreasOfInterestMessageContext()
+				aoiMessageContext : this._getAreasOfInterestMessageContext(),
+				incomingMethod : GDP.incomingMethod,
+				incomingParams : GDP.incomingParams
 			};
 
 			GDP.util.BaseView.prototype.initialize.apply(this, arguments);

--- a/src/main/webapp/js/landing/views/DataSourceSelectionView.js
+++ b/src/main/webapp/js/landing/views/DataSourceSelectionView.js
@@ -51,7 +51,6 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 			this.context = {
 				algorithmFilters : _.keys(this.algorithmFilters),
 				aoiMessageContext : this._getAreasOfInterestMessageContext(),
-				incomingMethod : GDP.incomingMethod,
 				incomingParams : GDP.incomingParams
 			};
 

--- a/src/main/webapp/js/landing/views/DataSourceSelectionView.js
+++ b/src/main/webapp/js/landing/views/DataSourceSelectionView.js
@@ -49,7 +49,8 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 				.groupBy('type')
 				.value());
 			this.context = {
-				algorithmFilters : _.keys(this.algorithmFilters)
+				algorithmFilters : _.keys(this.algorithmFilters),
+				aoiMessageContext : this._getAreasOfInterestMessageContext()
 			};
 
 			GDP.util.BaseView.prototype.initialize.apply(this, arguments);
@@ -124,6 +125,47 @@ GDP.LANDING.views = GDP.LANDING.views || {};
 			}
 
 			this.updateFilteredViews();
+		},
+
+		_getAreasOfInterestMessageContext : function() {
+			var context = {};
+			var parser;
+			var host;
+			var protocol;
+			if (GDP.incomingParams.caller && GDP.incomingParams.item_id) {
+				if (GDP.incomingParams.caller.toLowerCase() === 'sciencebase') {
+					/* We need to build the sciencebase url since its not included in the
+					 * request params.  Params passed in via ScienceBase look like:
+					 * 				caller: "sciencebase"
+					 *		 		development: "false"
+					 *		 		feature_wfs: "https://www.sciencebase.gov/catalogMaps/mapping/ows/54296bf0e4b0ad29004c2fbb"
+					 *		 		feature_wms: "https://www.sciencebase.gov/catalogMaps/mapping/ows/54296bf0e4b0ad29004c2fbb"
+					 *		 		item_id: "54296bf0e4b0ad29004c2fbb"
+					 *		 		ows: "https://www.sciencebase.gov/catalogMaps/mapping/ows/54296bf0e4b0ad29004c2fbb"
+					 *		 		redirect_url: "https://www.sciencebase.gov/catalog/gdp/landing/54296bf0e4b0ad29004c2fbb"
+					 *
+					 *		URL to sciencebase looks like:
+					 *				https://www.sciencebase.gov/catalog/item/54296bf0e4b0ad29004c2fbb
+					 *
+					 * So first thing is to get the request host
+					 */
+					parser = document.createElement('a');
+					parser.href = GDP.incomingParams.redirect_url;
+
+					host = parser.hostname;
+					protocol = parser.protocol;
+					context.sciencebase = {
+						url : protocol + "//" + host + "/catalog/item/" + GDP.incomingParams.item_id
+					};
+				}
+				else {
+					context.default = {
+						itemId : GDP.incomingParams.item_id,
+						caller : GDP.incomingParams.caller
+					};
+				}
+			}
+			return context;
 		}
 
 

--- a/src/main/webapp/js/ogc/wfs.js
+++ b/src/main/webapp/js/ogc/wfs.js
@@ -29,7 +29,7 @@ GDP.OGC.WFS = (function () {
 		$.extend(wfsData, defaultData, data);
 		GDP.logger.debug('GDP: Calling WFS Service with a ' + wfsData.request + ' request.');
 		$.ajax({
-			url: GDP.config.get('application').endpoints.geoserver + '/wfs',
+			url: GDP.config.get('application').endpoints.wfs,
 			method : (method) ? method : 'GET',
 			data: wfsData,
 			cache: false,

--- a/src/main/webapp/js/process_client/init.js
+++ b/src/main/webapp/js/process_client/init.js
@@ -33,6 +33,16 @@ $(document).ready(function() {
 			GDP.config = new GDP.model.Config(data);
 			var applicationConfig = GDP.config.get('application');
 
+			var application = GDP.config.get('application');
+			if (_.has(GDP.incomingParams, 'feature_wms')) {
+				application.endpoints.wms = GDP.incomingParams.feature_wms;
+			}
+			if (_.has(GDP.incomingParams, 'feature_wfs')) {
+				application.endpoints.wfs = GDP.incomingParams.feature_wfs;
+				application.serviceEndpoints.wfs = GDP.incomingParams.feature_wfs;
+			}
+			GDP.config.set({'application' : application});
+
 			GDP.cswClient = new GDP.OGC.CSW({
 				url : applicationConfig.endpoints.csw
 			});

--- a/src/main/webapp/js/process_client/init.js
+++ b/src/main/webapp/js/process_client/init.js
@@ -34,6 +34,7 @@ $(document).ready(function() {
 			var applicationConfig = GDP.config.get('application');
 
 			var application = GDP.config.get('application');
+			// Need to override the endpoints for services if they are in the incoming POST parameters
 			if (_.has(GDP.incomingParams, 'feature_wms')) {
 				application.endpoints.wms = GDP.incomingParams.feature_wms;
 			}

--- a/src/main/webapp/js/process_client/models/JobModel.js
+++ b/src/main/webapp/js/process_client/models/JobModel.js
@@ -65,7 +65,6 @@ var GDP = GDP || {};
 		},
 
 		/*
-		 *
 		 * @param {String} datasetId - Id of dataset to retrieve from sciencebase
 		 * @returns {jquery.Promise} - This promise is resolve if the data set model does not need to be updated or if it is
 		 * successfully updated. The promise is rejected if updating the datset failed. The dataSetModel property is also cleared.

--- a/src/main/webapp/js/process_client/views/HubView.js
+++ b/src/main/webapp/js/process_client/views/HubView.js
@@ -69,7 +69,7 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 			}).always(function() {
 				var datasetModel = self.model.get('dataSetModel');
 				var $metadataTile = self.$el.find('#dataset-metadata-wrapper');
-				
+
 				self.$el.find('.loading-indicator').hide();
 				self.$el.find('.hub-tile').show();
 				self.spatialMapView = new GDP.PROCESS_CLIENT.view.HubSpatialMapView({
@@ -145,7 +145,7 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 					['OUTPUT'],
 					true,
 					{
-						'FEATURE_COLLECTION' : [self.wps.createWfsWpsReference(GDP.config.get('application').serviceEndpoints.geoserver + '/wfs', xmlInputs)]
+						'FEATURE_COLLECTION' : [self.wps.createWfsWpsReference(GDP.config.get('application').serviceEndpoints.wfs, xmlInputs)]
 					},
 					false,
 					'xml',

--- a/src/main/webapp/js/process_client/views/SpatialView.js
+++ b/src/main/webapp/js/process_client/views/SpatialView.js
@@ -424,7 +424,7 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 				getFeatureDeferred = GDP.OGC.WFS.callWFS(
 					{
 						request : 'GetFeature',
-						typename : name,
+						typename : name.replace(ns_attribute + ':', ''),
 						propertyname : attribute,
 						maxFeatures : 5001 // Limits number of features shown in selection menu
 					}
@@ -621,7 +621,7 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 					'</wfs:Transaction>';
 
 				$.ajax({
-					url: GDP.config.get('application').endpoints.geoserver + '/wfs',
+					url: GDP.config.get('application').endpoints.wfs,
 					type: 'POST',
 					contentType: 'application/xml',
 					data: updateTransaction,
@@ -649,7 +649,7 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 				protocol: new OpenLayers.Protocol.WFS({
 					version: '1.1.0',
 					srsName: 'EPSG:4326',
-					url: GDP.config.get('application').endpoints.geoserver + '/wfs',
+					url: GDP.config.get('application').wfs,
 					featureNS :  'gov.usgs.cida.gdp.' + this._DRAW_FEATURE_NS,
 					featureType : "dummy-" + new Date().getTime() + '', // this gets changed before submitting geometry
 					geometryName: 'the_geom'

--- a/src/main/webapp/js/process_client/views/SpatialView.js
+++ b/src/main/webapp/js/process_client/views/SpatialView.js
@@ -541,7 +541,7 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 			};
 
 			$fileUploaderInput.fileupload({
-				url : 'uploadhandler?' +  $.param(params),
+				url : GDP.BASE_URL + 'uploadhandler?' +  $.param(params),
 				type: 'POST',
 				dataType: 'xml',
 				send : function(e, data) {
@@ -649,7 +649,7 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 				protocol: new OpenLayers.Protocol.WFS({
 					version: '1.1.0',
 					srsName: 'EPSG:4326',
-					url: GDP.config.get('application').wfs,
+					url: GDP.config.get('application').endpoints.wfs,
 					featureNS :  'gov.usgs.cida.gdp.' + this._DRAW_FEATURE_NS,
 					featureType : "dummy-" + new Date().getTime() + '', // this gets changed before submitting geometry
 					geometryName: 'the_geom'

--- a/src/main/webapp/js/util/mapUtils.js
+++ b/src/main/webapp/js/util/mapUtils.js
@@ -77,7 +77,7 @@ GDP.util.mapUtils = (function() {
 
 		return new OpenLayers.Layer.WMS(
 			'Area of Interest',
-			GDP.config.get('application').endpoints.geoserver + '/wms?',
+			GDP.config.get('application').endpoints.wms + '?',
 			layerParams,
 			layerOptions
 		);
@@ -135,7 +135,7 @@ GDP.util.mapUtils = (function() {
 
 		return new OpenLayers.Layer.WMS(
 			'Selected AOI',
-			GDP.config.get('application').endpoints.geoserver + '/wms?',
+			GDP.config.get('application').endpoints.wms + '?',
 			layerParams,
 			layerOptions
 		);

--- a/src/main/webapp/process_client.jsp
+++ b/src/main/webapp/process_client.jsp
@@ -4,7 +4,7 @@
 
     <head>
 		<%@include file="/WEB-INF/jsp/head.jsp" %>
-    	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<link rel="stylesheet" type="text/css" href="<%= baseUrl %>webjars/openlayers/<%= versionOpenLayers%>/theme/default/style.css" />
 		<link rel="stylesheet" type="text/css" href="<%= baseUrl %>webjars/jquery-file-upload/<%= versionJqueryFileUpload%>/css/jquery.fileupload.css">
 		<link rel="stylesheet" type="text/css" href="<%= baseUrl %>css/process_client_custom.css">

--- a/src/main/webapp/process_client.jsp
+++ b/src/main/webapp/process_client.jsp
@@ -3,7 +3,8 @@
 <html lang="en">
 
     <head>
-		<%@include file="/WEB-INF/jsp/head.jsp" %>			
+		<%@include file="/WEB-INF/jsp/head.jsp" %>
+    	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<link rel="stylesheet" type="text/css" href="<%= baseUrl %>webjars/openlayers/<%= versionOpenLayers%>/theme/default/style.css" />
 		<link rel="stylesheet" type="text/css" href="<%= baseUrl %>webjars/jquery-file-upload/<%= versionJqueryFileUpload%>/css/jquery.fileupload.css">
 		<link rel="stylesheet" type="text/css" href="<%= baseUrl %>css/process_client_custom.css">

--- a/src/main/webapp/templates/datasource_select.html
+++ b/src/main/webapp/templates/datasource_select.html
@@ -1,3 +1,20 @@
+<div class="jumbotron">
+	<h1>Welcome to GDP</h1>
+	<p>Here's where to put the latest and greatest information about GDP.</p>
+{{#if aoiMessageContext.sciencebase}}
+	<div>
+		<a href="{{aoiMessageContext.sciencebase.url}}" target="_blank">Areas of interest from ScienceBase already selected.</a>
+	</div>
+{{/if}}
+
+{{#if aoiMessageContext.default}}
+	<div>
+		Areas of interest {{aoiMessageContext.default.itemId}} from {{aoiMessageContext.default.caller}} already selected.
+	</div>
+{{/if}}
+</div>
+
+
 <div class="dataset-select-container">
 	
 	<div class="dataset-tile-panel-div panel panel-default">

--- a/src/main/webapp/templates/datasource_select.html
+++ b/src/main/webapp/templates/datasource_select.html
@@ -7,9 +7,9 @@
 	</div>
 {{/if}}
 
-{{#if aoiMessageContext.default}}
+{{#if aoiMessageContext.defaultCaller}}
 	<div>
-		Areas of interest {{aoiMessageContext.default.itemId}} from {{aoiMessageContext.default.caller}} already selected.
+		Areas of interest {{aoiMessageContext.defaultCaller.itemId}} from {{aoiMessageContext.defaultCaller.caller}} already selected.
 	</div>
 {{/if}}
 </div>

--- a/src/main/webapp/templates/datasource_select.html
+++ b/src/main/webapp/templates/datasource_select.html
@@ -55,8 +55,13 @@
 				<div class="dataset-dialog-contents"></div>
 			</div>
 			<div class="modal-footer">
-				<button type="button" class="btn btn-default cancel-btn">Cancel</button>
-				<button type="button" class="btn btn-primary process-btn">Process Data Source</button>
+				<form class="process-form" method="POST">
+					<button type="button" class="btn btn-default cancel-btn">Cancel</button>
+					{{#each incomingParams}}
+						<input type="hidden" name="{{@key}}" value="{{this}}" />
+					{{/each}}
+					<button type="submit" class="btn btn-primary process-btn">Process Data Source</button>
+				</form>
 			</div>
 		</div>
 	</div>

--- a/src/test/js/specs/DataSetDialogView_spec.js
+++ b/src/test/js/specs/DataSetDialogView_spec.js
@@ -1,3 +1,9 @@
+/*global GDP*/
+/*global jasmine*/
+/*global expect*/
+/*global OpenLayers*/
+/*global spyOn*/
+
 describe('GDP.LANDING.views.DataSetDialogView', function() {
 	var getDeferred;
 	var templateSpy;

--- a/src/test/js/specs/DataSourceSelectionView_spec.js
+++ b/src/test/js/specs/DataSourceSelectionView_spec.js
@@ -96,7 +96,7 @@ describe('GDP.LANDING.views.DataSourceSelectionView', function() {
 		});
 	});
 
-	it('Expects the template to be called with aoimessageContext property set with a default property when called param is not sciencebase', function() {
+	it('Expects the template to be called with aoimessageContext property set with a defaultCaller property when called param is not sciencebase', function() {
 		GDP.incomingParams = {
 			caller : 'otherservice',
 			item_id : '1234'
@@ -106,7 +106,7 @@ describe('GDP.LANDING.views.DataSourceSelectionView', function() {
 			collection : collection
 		});
 		expect(templateSpy.calls[0].args[0].aoiMessageContext).toEqual({
-			default : {
+			defaultCaller : {
 				itemId : '1234',
 				caller : 'otherservice'
 			}

--- a/src/test/js/specs/SpatialView_spec.js
+++ b/src/test/js/specs/SpatialView_spec.js
@@ -1,3 +1,10 @@
+/*global GDP*/
+/*global expect*/
+/*global jasmine*/
+/*global sinon*/
+/*global spyOn*/
+/*global OpenLayers*/
+
 describe('GDP.PROCESS_CLIENT.VIEW.SpatialView', function() {
 	var model;
 	var templateSpy;
@@ -14,7 +21,8 @@ describe('GDP.PROCESS_CLIENT.VIEW.SpatialView', function() {
 		GDP.config = new GDP.model.Config({
 			application : {
 				endpoints : {
-					geoserver : 'http://fakegeoserver.com'
+					wms : 'http://fakegeoserver.com/wms',
+					wfs : 'http://fakegeoserver.com/wfs'
 				}
 			},
 			process : {
@@ -68,7 +76,7 @@ describe('GDP.PROCESS_CLIENT.VIEW.SpatialView', function() {
 
 		spyOn($.fn, 'fileupload');
 
-		$('body').append('<div id="test-div"><div id="spatial-map"></div><input id="upload-shapefile-input" type="file" name="qqfile"></div>')
+		$('body').append('<div id="test-div"><div id="spatial-map"></div><input id="upload-shapefile-input" type="file" name="qqfile"></div>');
 
 
 		testView = new GDP.PROCESS_CLIENT.view.SpatialView({
@@ -147,11 +155,11 @@ describe('GDP.PROCESS_CLIENT.VIEW.SpatialView', function() {
 
 	it('Expects a change to aoiName to callWFS to make a DescribeFeatureType request', function() {
 		wfsDeferred.resolve();
-		testView.model.set('aoiName', 'featureName');
+		testView.model.set('aoiName', 'tst:featureName');
 		expect(callWFSSpy.calls.length).toBe(2);
 		var callWfsArgs = callWFSSpy.mostRecentCall.args;
 		expect(callWfsArgs[0].request).toEqual('DescribeFeatureType');
-		expect(callWfsArgs[0].typename).toEqual('featureName');
+		expect(callWfsArgs[0].typename).toEqual('tst:featureName');
 	});
 
 	it('Expects a change to aoiName which is using the draw namepsace to set the aoiAttribute', function() {
@@ -164,7 +172,7 @@ describe('GDP.PROCESS_CLIENT.VIEW.SpatialView', function() {
 
 	it('Expects a change to aoiAttribute to callWFS to make GetFeature request', function() {
 		wfsDeferred.resolve();
-		testView.model.set('aoiName', 'featureName');
+		testView.model.set('aoiName', 'tst:featureName');
 		testView.model.set('aoiAttribute', 'attr1');
 
 		expect(callWFSSpy.calls.length).toBe(3);
@@ -178,8 +186,8 @@ describe('GDP.PROCESS_CLIENT.VIEW.SpatialView', function() {
 	//TODO: Add tests to build DOM correctly from GetFeature response when aoiAttribute is changed
 
 	it('Expects changeName to change the model\'s aoiName property', function() {
-		testView.changeName({ target : { value : 'thisFeature' } });
-		expect(testView.model.get('aoiName')).toEqual('thisFeature');
+		testView.changeName({ target : { value : 'tst:thisFeature' } });
+		expect(testView.model.get('aoiName')).toEqual('tst:thisFeature');
 	});
 
 	it('Expects changeAttribute to change the model\'s aoiAttribute property', function() {


### PR DESCRIPTION
Added the ability to use POST or GET parameters on the landing page and forward them via a POST to the client so that a different wms/wfs service can be specified. Much of the code was lifted from the old gdp ui and landing page code.

A couple of things to note. What was the endpoints.geoserver has been split into endpoints.wms and endpoints.wfs which are overridden when specified in the POST form. Also the GetFeature request to the sciencebase service failed if the features typeName included the namespace, so I filter it out before sending the request.