### PR TITLE
Use responseText if responseXML is null. This is required for IE10.

### DIFF
--- a/src/main/webapp/js/util/mapUtils.js
+++ b/src/main/webapp/js/util/mapUtils.js
@@ -184,7 +184,7 @@ GDP.util.mapUtils = (function() {
 				version : '1.3.0'
 			},
 			success : function(response) {
-				var respObj = format.read(response.responseXML);
+				var respObj = format.read(response.responseXML || response.responseText);
 				if (_.has(respObj, 'error')) {
 					GDP.debug('Unsuccessfully retrieved wms capabilities');
 					layer = that.createDataSetExtentLayer(boundingBox);


### PR DESCRIPTION
Same fix as before, different place.