### PR TITLE
Gdp 985

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,10 +331,10 @@
 						<source>webjars/backbone.js</source>
 						<source>webjars/handlebars.js</source>
 						<source>webjars/OpenLayers.js</source>
-						<source>webjars/bootstrap-datepicker.js</source>
 						<source>webjars/jquery-ui.js</source>
 						<source>webjars/jquery.fileupload.js</source>
 						<source>vendor/jQuery.download.js</source>
+						<source>webjars/bootstrap-datepicker.js</source>
 					</preloadSources>
 					<sourceIncludes>
 						<include>util/**.js</include>

--- a/src/main/webapp/js/process_client/controller/ProcessClientRouter.js
+++ b/src/main/webapp/js/process_client/controller/ProcessClientRouter.js
@@ -10,9 +10,8 @@ GDP.PROCESS_CLIENT.controller.ProcessClientRouter = Backbone.Router.extend({
 
 	applicationContextDiv : '#advanced-page-content',
 	jobModel: null,
-	initialize: function(jobModel, wps){
+	initialize: function(jobModel){
 	  this.jobModel = jobModel;
-	  this.wps = wps;
 	},
 	routes : {
 		'!advanced' : 'hub',
@@ -49,9 +48,7 @@ GDP.PROCESS_CLIENT.controller.ProcessClientRouter = Backbone.Router.extend({
 		this.showView(GDP.PROCESS_CLIENT.view.DataDetailsView, {
 			template : GDP.PROCESS_CLIENT.templates.getTemplate('datadetail'),
 			model: this.jobModel,
-			datasetId : datasetid,
-			wps: this.wps,
-			wpsEndpoint: GDP.config.get('application').endpoints.utilityWps
+			datasetId : datasetid
 		});
 	},
 

--- a/src/main/webapp/js/process_client/init.js
+++ b/src/main/webapp/js/process_client/init.js
@@ -72,8 +72,8 @@ $(document).ready(function() {
 		var jobModel = new GDP.PROCESS_CLIENT.model.Job();
 		jobModel.get('processes').reset(GDP.config.get('process').processes);
 
-		var wps = GDP.OGC.WPS(GDP.logger);
-		GDP.PROCESS_CLIENT.router = new GDP.PROCESS_CLIENT.controller.ProcessClientRouter(jobModel, wps);
+		GDP.wpsClient = GDP.OGC.WPS(GDP.logger);
+		GDP.PROCESS_CLIENT.router = new GDP.PROCESS_CLIENT.controller.ProcessClientRouter(jobModel);
 
 		var origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
 		var root  = GDP.BASE_URL.replace(origin, '');

--- a/src/main/webapp/js/process_client/models/DataSourceModels.js
+++ b/src/main/webapp/js/process_client/models/DataSourceModels.js
@@ -1,5 +1,6 @@
 /*jslint browser: true*/
 /*global Backbone*/
+/*global _*/
 var GDP = GDP || {};
 (function(){
     "use strict";
@@ -7,18 +8,168 @@ var GDP = GDP || {};
 
     GDP.PROCESS_CLIENT.model = GDP.PROCESS_CLIENT.model || {};
 
+	var VARIABLE_WPS_PROCESS_ID = 'gov.usgs.cida.gdp.wps.algorithm.discovery.ListOpendapGrids';
+	var DATE_RANGE_WPS_PROCESS_ID = 'gov.usgs.cida.gdp.wps.algorithm.discovery.GetGridTimeRange';
+
     var DataSourceVariable = Backbone.Model.extend({
-	defaults:{
-	    text: '',
-	    value: null,
-	    selected: false
-	}
-    });
+		defaults:{
+			name : '',
+			description : '',
+			unitsstring : ''
+		}
+	});
 
     var DataSourceVariables = Backbone.Collection.extend({
-	model: DataSourceVariable
+		model: DataSourceVariable,
+
+		fetch : function(options) {
+			var self = this;
+			var deferred = $.Deferred();
+			var wpsInputs = {
+				"catalog-url": [options.dataSourceUrl],
+				"allow-cached-response": [options.allow_cached]
+			};
+			var wpsOutput = ["result_as_json"];
+
+			GDP.wpsClient.sendWpsExecuteRequest(
+				GDP.config.get('application').endpoints.utilityWps + '/WebProcessingService',
+				VARIABLE_WPS_PROCESS_ID,
+				wpsInputs,
+				wpsOutput,
+				false,
+				null,
+				true,
+				'json',
+				'application/json'
+			).done(function(response) {
+				var dataCollection;
+				if (response && _.has(response, 'datatypecollection') && _.has(response.datatypecollection, 'types')) {
+					if (_.has(response.datatypecollection.types, 'length')) {
+						dataCollection = response.datatypecollection.types;
+					}
+					else {
+						dataCollection = [response.datatypecollection.types];
+					}
+					// Need to retrieve dates now. The dates are the same for all variables so use the first in the list
+					self.add(_.map(dataCollection, function(c) {
+						return {
+							name : c.name,
+							description : c.description,
+							unitsstring : c.unitsstring
+						};
+					}));
+					deferred.resolve();
+				}
+				else {
+					deferred.reject(VARIABLE_WPS_PROCESS_ID + ' : Invalid wps response received');
+				}
+			}).fail(function(jqXHR, textStatus) {
+				deferred.reject(VARIABLE_WPS_PROCESS_ID + ' : Service request failed with ' + textStatus);
+			});
+
+			return deferred.promise();
+		}
     });
+
+	var DataSourceModel =  Backbone.Model.extend({
+		defaults : {
+			url : '',
+			variables : new DataSourceVariables(),
+			minDate : '',
+			maxDate : ''
+		},
+
+		getDateRange : function(options) {
+			// date range is the same for all variables, so just use the first one in the collection
+			var self = this;
+			var deferred = $.Deferred();
+			var wpsInputs = {
+				"catalog-url": [this.get('url')],
+				"allow-cached-response": [options.allowCached],
+				"grid": [this.get('variables').at(0).get('name')]
+			};
+			var wpsOutput = ["result_as_json"];
+
+			var hasExpectedDateProperties = function(obj) {
+				var expectedProperties = ['year','month','day'];
+				var hasExpectedNumericProperties = true;
+
+				if (_.isObject(obj)) {
+					var picked = _.pick(obj, expectedProperties);
+					if(_.keys(picked).length !== expectedProperties.length){
+						hasExpectedNumericProperties = false;
+					}
+					else {
+						var valuesAreNumeric = _.chain(picked).values().every(_.isNumber).value();
+						if(!valuesAreNumeric){
+							hasExpectedNumericProperties = false;
+						}
+					}
+				}
+				else{
+					hasExpectedNumericProperties = false;
+				}
+				return hasExpectedNumericProperties;
+			};
+
+			GDP.wpsClient.sendWpsExecuteRequest(
+				GDP.config.get('application').endpoints.utilityWps + '/WebProcessingService',
+				DATE_RANGE_WPS_PROCESS_ID,
+				wpsInputs,
+				wpsOutput,
+				false,
+				null,
+				true,
+				'json',
+				'application/json'
+			).done(function(response) {
+				var starttime, endtime;
+				if (_.has(response, 'availabletimes') && _.has(response.availabletimes, 'starttime') &&
+					_.has(response.availabletimes, 'endtime')  &&
+					hasExpectedDateProperties(response.availabletimes.starttime) &&
+					hasExpectedDateProperties(response.availabletimes.endtime)) {
+
+					starttime = response.availabletimes.starttime;
+					endtime = response.availabletimes.endtime;
+
+					self.set('minDate', starttime.month + '/'  + starttime.day + '/' + starttime.year);
+					self.set('maxDate', endtime.month + '/'  + endtime.day + '/' + endtime.year);
+
+					deferred.resolve();
+				}
+				else {
+					deferred.reject(DATE_RANGE_WPS_PROCESS_ID + ' : Invalid response received');
+				}
+			}).fail(function(jqXHR, textStatus) {
+				deferred.reject(DATE_RANGE_WPS_PROCESS_ID + ' : Service call failed: ' + textStatus);
+			});
+
+			return deferred.promise();
+		},
+
+		fetch : function(options) {
+			var self = this;
+			var deferred = $.Deferred();
+			var variables = new DataSourceVariables();
+			this.set('url', options.dataSourceUrl);
+
+			variables.fetch(options).done(function() {
+				self.set('variables', variables);
+				self.getDateRange({
+					allowCache : options.allowCache
+				}).done(function() {
+					deferred.resolve();
+				}).fail(function(msg) {
+					deferred.reject(msg);
+				});
+			}).fail(function(msg) {
+				deferred.reject(msg);
+			});
+			return deferred.promise();
+		}
+	});
 
     GDP.PROCESS_CLIENT.model.DataSourceVariable = DataSourceVariable;
     GDP.PROCESS_CLIENT.model.DataSourceVariables = DataSourceVariables;
+	GDP.PROCESS_CLIENT.model.DataSourceModel = DataSourceModel;
 }());

--- a/src/main/webapp/js/process_client/models/DataSourceModels.js
+++ b/src/main/webapp/js/process_client/models/DataSourceModels.js
@@ -22,12 +22,18 @@ var GDP = GDP || {};
     var DataSourceVariables = Backbone.Collection.extend({
 		model: DataSourceVariable,
 
+		/*
+		 * @param {Object} options
+		 *     @prop {String} dataSourceUrl - The catalog url to be used to retrieve the data variables
+		 *     @prop {Boolean} allowCached
+		 *  @returns a promise that is resolved when the variables are succussfully retrieve, otherwise rejected
+		 */
 		fetch : function(options) {
 			var self = this;
 			var deferred = $.Deferred();
 			var wpsInputs = {
 				"catalog-url": [options.dataSourceUrl],
-				"allow-cached-response": [options.allow_cached]
+				"allow-cached-response": [options.allowCached ? 'true' : 'false']
 			};
 			var wpsOutput = ["result_as_json"];
 
@@ -76,18 +82,24 @@ var GDP = GDP || {};
 			url : '',
 			variables : new DataSourceVariables(),
 			dateRange : {
-				minDate : '',
-				maxDate : ''
+				start : '',
+				end : ''
 			}
 		},
 
+		/*
+		 * This will use the url and variables in the model so these should already be defined
+		 * @param {Object} options
+		 *     @prop {Boolean} allowCached
+		 * @returns {Jquery.promise} - resolved if the dateRange is successfully retrieve, otherwise rejected
+		 */
 		getDateRange : function(options) {
 			// date range is the same for all variables, so just use the first one in the collection
 			var self = this;
 			var deferred = $.Deferred();
 			var wpsInputs = {
 				"catalog-url": [this.get('url')],
-				"allow-cached-response": [options.allowCached],
+				"allow-cached-response": [options.allowCached ? 'true' : 'false'],
 				"grid": [this.get('variables').at(0).get('name')]
 			};
 			var wpsOutput = ["result_as_json"];

--- a/src/main/webapp/js/process_client/models/DataSourceModels.js
+++ b/src/main/webapp/js/process_client/models/DataSourceModels.js
@@ -75,8 +75,10 @@ var GDP = GDP || {};
 		defaults : {
 			url : '',
 			variables : new DataSourceVariables(),
-			minDate : '',
-			maxDate : ''
+			dateRange : {
+				minDate : '',
+				maxDate : ''
+			}
 		},
 
 		getDateRange : function(options) {
@@ -132,8 +134,10 @@ var GDP = GDP || {};
 					starttime = response.availabletimes.starttime;
 					endtime = response.availabletimes.endtime;
 
-					self.set('minDate', starttime.month + '/'  + starttime.day + '/' + starttime.year);
-					self.set('maxDate', endtime.month + '/'  + endtime.day + '/' + endtime.year);
+					self.set('dateRange', {
+						start : starttime.month + '/'  + starttime.day + '/' + starttime.year,
+						end : endtime.month + '/'  + endtime.day + '/' + endtime.year
+					});
 
 					deferred.resolve();
 				}

--- a/src/main/webapp/js/process_client/models/DataSourceModels.js
+++ b/src/main/webapp/js/process_client/models/DataSourceModels.js
@@ -26,7 +26,7 @@ var GDP = GDP || {};
 		 * @param {Object} options
 		 *     @prop {String} dataSourceUrl - The catalog url to be used to retrieve the data variables
 		 *     @prop {Boolean} allowCached
-		 *  @returns a promise that is resolved when the variables are succussfully retrieve, otherwise rejected
+		 *  @returns a promise that is resolved when the variables are succussfully retrieve, otherwise rejected with a String error message.
 		 */
 		fetch : function(options) {
 			var self = this;
@@ -58,11 +58,7 @@ var GDP = GDP || {};
 					}
 					// Need to retrieve dates now. The dates are the same for all variables so use the first in the list
 					self.add(_.map(dataCollection, function(c) {
-						return {
-							name : c.name,
-							description : c.description,
-							unitsstring : c.unitsstring
-						};
+						return _.pick(c, 'name', 'description', 'unitsstring');
 					}));
 					deferred.resolve();
 				}
@@ -91,7 +87,7 @@ var GDP = GDP || {};
 		 * This will use the url and variables in the model so these should already be defined
 		 * @param {Object} options
 		 *     @prop {Boolean} allowCached
-		 * @returns {Jquery.promise} - resolved if the dateRange is successfully retrieve, otherwise rejected
+		 * @returns {Jquery.promise} - resolved if the dateRange is successfully retrieve, otherwise rejected with a String error message.
 		 */
 		getDateRange : function(options) {
 			// date range is the same for all variables, so just use the first one in the collection
@@ -163,6 +159,11 @@ var GDP = GDP || {};
 			return deferred.promise();
 		},
 
+		/*
+		 * @param {Object} options
+		 *     @prop {String} dataSourceUrl - The url for a data source.
+		 *     @prop {Boolean} allowCached - Set to true if cached response is acceptable
+		 */
 		fetch : function(options) {
 			var self = this;
 			var deferred = $.Deferred();
@@ -172,7 +173,7 @@ var GDP = GDP || {};
 			variables.fetch(options).done(function() {
 				self.set('variables', variables);
 				self.getDateRange({
-					allowCache : options.allowCache
+					allowCached : options.allowCached
 				}).done(function() {
 					deferred.resolve();
 				}).fail(function(msg) {
@@ -185,7 +186,7 @@ var GDP = GDP || {};
 		}
 	});
 
-    GDP.PROCESS_CLIENT.model.DataSourceVariable = DataSourceVariable;
-    GDP.PROCESS_CLIENT.model.DataSourceVariables = DataSourceVariables;
+	GDP.PROCESS_CLIENT.model.DataSourceVariable = DataSourceVariable;
+	GDP.PROCESS_CLIENT.model.DataSourceVariables = DataSourceVariables;
 	GDP.PROCESS_CLIENT.model.DataSourceModel = DataSourceModel;
 }());

--- a/src/main/webapp/js/process_client/models/JobModel.js
+++ b/src/main/webapp/js/process_client/models/JobModel.js
@@ -86,7 +86,7 @@ var GDP = GDP || {};
 							dataSetModel.clear();
 							deferred.reject('No dataset record returned for ' + datasetId);
 						}
-					}).fail(function() {
+					}).fail(function(msg) {
 						GDP.logger.error('Could not GetRecordsById for ' + datasetId);
 						dataSetModel.clear();
 						deferred.reject(msg);
@@ -203,9 +203,7 @@ var GDP = GDP || {};
 
 			/* The following property always need to be specified */
 			var result = {
-				DATASET_ID : _.map(this.get('dataVariables'), function(model) {
-					return model.get('value');
-				})
+				DATASET_ID : this.get('dataVariables')
 			};
 
 			/* The rest of the properties should only be specified if in validInputs */

--- a/src/main/webapp/js/process_client/models/JobModel.js
+++ b/src/main/webapp/js/process_client/models/JobModel.js
@@ -34,18 +34,13 @@ var GDP = GDP || {};
 			dataSetModel : null,
 			//data details
 			dataSourceUrl : null,
-			invalidDataSourceUrl : true,
-			dataSourceVariables : new GDP.PROCESS_CLIENT.model.DataSourceVariables(),
+			//details about the selected dataSourceUrl
+			dataSourceModel : new GDP.PROCESS_CLIENT.model.DataSourceModel(),
 
-			//the earliest date the user can select
-			minDate: null,
-
-			//the latest date the user can select
-			maxDate: null,
-
+			dataVariables : [],
 			//the dates the user actually selected
-			startDate: null,
-			endDate: null,
+			startDate: '',
+			endDate: '',
 
 			//spatial details:
 			aoiName : '',
@@ -89,12 +84,12 @@ var GDP = GDP || {};
 						}
 						else {
 							dataSetModel.clear();
-							deferred.reject();
+							deferred.reject('No dataset record returned for ' + datasetId);
 						}
 					}).fail(function() {
 						GDP.logger.error('Could not GetRecordsById for ' + datasetId);
 						dataSetModel.clear();
-						deferred.reject();
+						deferred.reject(msg);
 					});
 				}
 				else { // Already set
@@ -171,14 +166,6 @@ var GDP = GDP || {};
 		},
 
 		/*
-		 * Return the data source variables whose selected attribute is true.
-		 * @returns {Array of GDP.PROCESS_CLIENT.model.DataSourceVariables}
-		 */
-		getSelectedDataSourceVariables : function() {
-			return this.get('dataSourceVariables').where({'selected' : true});
-		},
-
-		/*
 		 * Returns the inputs that are comprise the inputs to be used as processVariables.
 		 * @returns {Object} or null if no algorithm has been selected
 		 */
@@ -216,7 +203,7 @@ var GDP = GDP || {};
 
 			/* The following property always need to be specified */
 			var result = {
-				DATASET_ID : _.map(this.getSelectedDataSourceVariables(), function(model) {
+				DATASET_ID : _.map(this.get('dataVariables'), function(model) {
 					return model.get('value');
 				})
 			};
@@ -337,7 +324,7 @@ var GDP = GDP || {};
 				result.push('Enter a valid data source url and select variables.');
 			}
 			else {
-				if (this.getSelectedDataSourceVariables().length === 0) {
+				if (this.get('dataVariables').length === 0) {
 					result.push('Select at least one variable');
 				}
 				if (!this.get('startDate') && !this.get('endDate')) {

--- a/src/main/webapp/js/process_client/models/JobModel.js
+++ b/src/main/webapp/js/process_client/models/JobModel.js
@@ -62,7 +62,8 @@ var GDP = GDP || {};
 		/*
 		 * @param {String} datasetId - Id of dataset to retrieve from sciencebase
 		 * @returns {jquery.Promise} - This promise is resolve if the data set model does not need to be updated or if it is
-		 * successfully updated. The promise is rejected if updating the datset failed. The dataSetModel property is also cleared.
+		 * successfully updated. The promise is rejected if updating the dataset failed and an error message is returned.
+		 * The dataSetModel property is also cleared.
 		 */
 		updateDataSetModel : function(datasetId) {
 			var dataSetModel = this.get('dataSetModel');
@@ -201,7 +202,7 @@ var GDP = GDP || {};
 
 			var getDataSourceUrl = this.getWCSDataSourceUrl();
 
-			/* The following property always need to be specified */
+			/* The following property always need to be specified. It should contain the array of selected variables*/
 			var result = {
 				DATASET_ID : this.get('dataVariables')
 			};

--- a/src/main/webapp/js/process_client/views/DataDetailsView.js
+++ b/src/main/webapp/js/process_client/views/DataDetailsView.js
@@ -201,11 +201,6 @@ var GDP = GDP || {};
 
 		changeDateRange : function() {
 			var dateRange = this.model.get('dataSourceModel').get('dateRange');
-			var $startDate = this.$(datePickers.start.selector);
-			var $endDate = this.$(datePickers.end.selector);
-
-			$startDate.prop('disabled', !dateRange.start);
-			$endDate.prop('disabled', !dateRange.end);
 
 			this.updateStartEndDates(dateRange);
 
@@ -223,11 +218,14 @@ var GDP = GDP || {};
 
 			if ('' === startDate){
 				$startDate.datepicker('clearDates');
+
 			}
 			else{
 				this.$(datePickers.end.selector).datepicker('setStartDate', startDate);
 				$startDate.datepicker('setDate', startDate);
 			}
+			$startDate.prop('disabled', !startDate);
+
 		},
 		'changeEndDate' : function(){
 			var endDate = this.model.get('endDate');
@@ -240,6 +238,9 @@ var GDP = GDP || {};
 				this.$(datePickers.start.selector).datepicker('setEndDate', endDate);
 				$endDate.datepicker('setDate', endDate);
 			}
+
+			$endDate.prop('disabled', !endDate);
+
 		},
 
 		'render' : function () {

--- a/src/main/webapp/js/process_client/views/DataDetailsView.js
+++ b/src/main/webapp/js/process_client/views/DataDetailsView.js
@@ -24,76 +24,102 @@ var GDP = GDP || {};
 		selector : '#data-source-select'
 	};
 
-	var VARIABLE_WPS_PROCESS_ID = 'gov.usgs.cida.gdp.wps.algorithm.discovery.ListOpendapGrids';
-	var DATE_RANGE_WPS_PROCESS_ID = 'gov.usgs.cida.gdp.wps.algorithm.discovery.GetGridTimeRange';
-
     GDP.PROCESS_CLIENT.view.DataDetailsView = GDP.util.BaseView.extend({
 	'events' : (function(){
 		var ret = {};
 		ret['change ' + variablePicker.selector] = 'setSelectedVariables';
 		ret['change ' + urlTextPicker.selector] = 'setUrl';
 		ret['change ' + dataSourcePicker.selector] = 'setUrl';
-		ret['changeDate ' + datePickers.start.selector] = 'setStartDate';
-		ret['changeDate ' + datePickers.end.selector] = 'setEndDate';
+		ret['change ' + datePickers.start.selector] = 'setStartDate';
+		ret['change ' + datePickers.end.selector] = 'setEndDate';
 		ret['submit form'] = 'goToHubPage';
 		return ret;
 	}()),
-	'wps' : null,
+
+	getDataSourceOptions : function() {
+		var dataSourceUrl = this.model.get('dataSourceUrl');
+		var dataSources = this.model.get('dataSetModel').get('dataSources');
+
+		return _.map(dataSources, function(dataSource) {
+			return {
+				text : dataSource.title,
+				value : dataSource.url,
+				selected : dataSource.url === dataSourceUrl
+			};
+		});
+	},
+
+	getVariableOptions : function() {
+		var dataVariables = this.model.get('dataVariables');
+		var variableCollection = this.model.get('dataSourceModel').get('variables');
+		return _.map(variableCollection.models, function(variableModel){
+			var varAttributes = variableModel.attributes;
+			return {
+				text : varAttributes.name + ' - ' + varAttributes.description + ' (' + varAttributes.unitsstring + ")",
+				value : varAttributes.name,
+				selected : _.contains(dataVariables, varAttributes.name)
+			};
+		});
+	},
 
 	/*
 	 *
 	 * @param {Object} options
 	 *     @prop {Function} template - returns a function which will render the template for this view
 	 *     @prop {GDP.PROCESS_CLIENT.JobModel} model
-	 *     @prop {String} datasetid,
-	 *     @prop {GDP.OGC.WPS instance} wps
-	 *     @prop {String} wpsEndPoint
+	 *     @prop {String} datasetId,
 	 */
 	'initialize': function(options) {
 		var self = this;
-		var initArguments = arguments;
+		//Fetch data set model
+		var getDataSetModelPromise = this.model.updateDataSetModel(options.datasetId);
+		var hasVariables = this.model.get('dataSourceModel').get('variables').length > 0;
 
-		this.wps = options.wps;
 		this.routePrefix = options.datasetId ? '#!catalog/gdp/dataset/' + options.datasetId : '#!advanced';
-		this.wpsEndpoint = options.wpsEndpoint;
 
-		this.model.updateDataSetModel(options.datasetId).always(function() {
-			var dataSources = self.model.get('dataSetModel').get('dataSources');
-			if ((_.has(dataSources, 'length')) && (dataSources.length === 1)) {
-				self.model.set('dataSourceUrl', dataSources[0].url);
-				self.model.set('invalidDataSourceUrl', false);
-			}
-			self.context = {
-				dataSources : dataSources,
-				dataSourceUrl : self.model.get('dataSourceUrl')
-			};
-			//super
-			GDP.util.BaseView.prototype.initialize.apply(self, initArguments);
+		this.context = this.model.attributes;
+		this.context.hasDataSources = options.datasetId;
 
-			self.listenTo(self.model, 'change:dataSourceUrl', self.changeUrl);
-			self.listenTo(self.model.get('dataSourceVariables'), 'reset', self.changeAvailableVariables);
-			self.listenTo(self.model, 'change:invalidDataSourceUrl', self.changeInvalidUrl);
-			self.listenTo(self.model, 'change:minDate', self.changeMinDate);
-			self.listenTo(self.model, 'change:maxDate', self.changeMaxDate);
-			self.listenTo(self.model, 'change:startDate', self.changeStartDate);
-			self.listenTo(self.model, 'change:endDate', self.changeEndDate);
+		//super
+		GDP.util.BaseView.prototype.initialize.apply(self, arguments);
 
-			if (((_.has(dataSources, 'length')) && dataSources.length === 1) && (self.model.get('dataSourceVariables').length === 0)) {
-				// Need to retrieve the variables
-				self.changeUrl();
-			}
+		if (options.datasetId) {
+			this.dataSourceSelectMenuView = new GDP.util.SelectMenuView({
+				sortBy : 'text',
+				emptyPlaceholder : true,
+				menuOptions : this.getDataSourceOptions(),
+				el : '#data-source-select'
+			});
+		}
 
-			self.changeAvailableVariables();
-			self.changeInvalidUrl();
+		this.variablesSelectMenuView = new GDP.util.SelectMenuView({
+				el : variablePicker.selector,
+				emptyPlaceholder : false,
+				sortOptions: false,
+				menuOptions : this.getVariableOptions()
+		});
+		if (hasVariables) {
+			this.$(variablePicker.selector).prop('disabled', !hasVariables);
+		}
+
+		getDataSetModelPromise.done(function() {
+			var dataSourceModel = self.model.get('dataSourceModel');
+			self.dataSourceSelectMenuView.updateMenuOptions(self.getDataSourceOptions());
+
+			self.updateVariables();
+			self.changeVariables();
 			self.changeMinDate();
 			self.changeMaxDate();
 			self.changeStartDate();
 			self.changeEndDate();
-		}).fail(function() {
-			self.alertView = new GDP.util.AlertView({
-				el : '#messages-div'
-			});
-			self.alertView.show('alert-danger', 'Unable to load information about the dataset, ' + options.datasetId);
+
+			self.listenTo(self.model, 'change:dataSourceUrl', self.changeUrl);
+			self.listenTo(dataSourceModel, 'change:variables', self.updateVariables);
+			self.listenTo(dataSourceModel, 'change:minDate', self.changeMinDate);
+			self.listenTo(dataSourceModel, 'change:maxDate', self.changeMaxDate);
+			self.listenTo(self.model, 'change:dataVariables', self.changeVariables);
+			self.listenTo(self.model, 'change:startDate', self.changeStartDate);
+			self.listenTo(self.model, 'change:endDate', self.changeEndDate);
 		});
 	},
 	'setEndDate' : function(ev){
@@ -101,12 +127,6 @@ var GDP = GDP || {};
 	},
 	'setStartDate' : function(ev){
 		this.model.set('startDate', ev.target.value);
-	},
-	'setMaxDate' : function(ev){
-		this.model.set('maxDate', ev.target.value);
-	},
-	'setMinDate' : function(ev){
-		this.model.set('minDate', ev.target.value);
 	},
 	'setUrl' : function(ev){
 		this.model.set('dataSourceUrl', ev.target.value);
@@ -121,35 +141,83 @@ var GDP = GDP || {};
 		this.router.navigate(this.routePrefix, {trigger : true});
 	},
 
-	'changeMinDate' : function(){
-		var minDate = this.model.get('minDate');
-		$(datePickers.start.selector).datepicker('setStartDate', minDate);
+	changeUrl : function() {
+		var dataSourceUrl = this.model.get('dataSourceUrl');
+		var dataSourceModel = this.model.get('dataSourceModel');
+
+		this.$(dataSourcePicker.selector).val(dataSourceUrl);
+		this.$(urlTextPicker.selector).val(dataSourceUrl);
+
+		this.model.set('dataVariable', []);
+		this.model.set('startDate', '');
+		this.model.set('endDate', '');
+		if (dataSourceUrl) {
+			dataSourceModel.fetch({
+				dataSourceUrl : dataSourceUrl,
+				allowCache : this.$('#use-cached-checkbox').is(':checked')
+			}).fail(function(msg) {
+				//TODO: better error handling
+				GDP.logger.debug(msg);
+				window.alert(msg);
+			});
+		}
 	},
-	'changeMaxDate' : function(){
-		var maxDate = this.model.get('maxDate');
-		$(datePickers.end.selector).datepicker('setEndDate', maxDate);
+
+	updateVariables : function() {
+		var dataSourceModel = this.model.get('dataSourceModel');
+		var variables = dataSourceModel.get('variables');
+		var $variablePicker = this.$(variablePicker.selector);
+		this.variablesSelectMenuView.updateMenuOptions(this.getVariableOptions());
+		$variablePicker.prop('disabled', !variables.length);
 	},
+
+	changeMinDate : function() {
+		var dataSourceModel = this.model.get('dataSourceModel');
+		var minDate = dataSourceModel.get('minDate');
+		var $startDate = this.$(datePickers.start.selector);
+		$startDate.prop('disabled', !minDate);
+		$startDate.datepicker('setStartDate', minDate);
+		$startDate.datepicker('update', minDate);
+	},
+
+	changeMaxDate : function() {
+		var dataSourceModel = this.model.get('dataSourceModel');
+		var maxDate = dataSourceModel.get('maxDate');
+		var $endDate = this.$(datePickers.end.selector);
+		$endDate.prop('disabled', !maxDate);
+		$endDate.datepicker('setEndDate', maxDate);
+		$endDate.datepicker('update', maxDate);
+
+	},
+
+	changeVariables : function() {
+		this.$(variablePicker.selector).val(this.model.get('dataVariables'));
+	},
+
 	'changeStartDate' : function(){
 		var startDate = this.model.get('startDate');
-		if(null === startDate){
-			$(datePickers.start.selector).datepicker('clearDates');
+		var $startDate = this.$(datePickers.start.selector);
+
+		if (null === startDate){
+			$startDate.datepicker('clearDates');
 		}
 		else{
-			$(datePickers.start.selector).datepicker('setDate', startDate);
-			$(datePickers.end.selector).datepicker('setStartDate', startDate);
+			$startDate.datepicker('update', startDate);
+			this.$(datePickers.end.selector).datepicker('setStartDate', startDate);
 		}
 	},
 	'changeEndDate' : function(){
 		var endDate = this.model.get('endDate');
+		var $endDate = this.$(datePickers.end.selector);
+
 		if(null === endDate){
-			$(datePickers.end.selector).datepicker('clearDates');
+			$endDate.datepicker('clearDates');
 		}
 		else{
-			$(datePickers.end.selector).datepicker('setDate', endDate);
-			$(datePickers.start.selector).datepicker('setEndDate', endDate);
+			$endDate.datepicker('update', endDate);
+			this.$(datePickers.start.selector).datepicker('setEndDate', endDate);
 		}
 	},
-	'selectMenuView' : null,
 
 	'render' : function () {
 		this.$el.html(this.template(this.context));
@@ -158,270 +226,20 @@ var GDP = GDP || {};
 				emptyPlaceholder : false,
 				sortOptions: false
 		});
-		$(datePickers.start.selector).datepicker();
-		$(datePickers.end.selector).datepicker();
+		this.$(datePickers.start.selector).datepicker();
+		this.$(datePickers.end.selector).datepicker();
 		return this;
 	},
 
 	remove : function() {
-		this.selectMenuView.remove();
+		this.dataSourceSelectMenuView.remove();
+		this.variablesSelectMenuView.remove();
 		GDP.util.BaseView.prototype.remove.apply(this, arguments);
 
 	},
 
-	'dateModelProperties' : ['minDate', 'startDate', 'maxDate', 'endDate'],
-	'resetDates': function(){
-		var self = this;
-		_.each(this.dateModelProperties, function(dateProp){
-			self.model.set(dateProp, null);
-		});
-	},
 	'setSelectedVariables' : function (ev) {
-		var variables = _.map(ev.target.options, function (option) {
-				return {
-					'text': option.text,
-					'value': option.value,
-					'selected': option.selected
-				};
-			});
-
-		var dataSourceVariables = this.model.get('dataSourceVariables');
-
-		dataSourceVariables.set(variables);
-	},
-	/**
-	 * On model change, updates the dom to reflect the current data source's
-	 * available variables in <option> elements in a <select>
-	 * @returns {undefined}
-	 */
-	'changeAvailableVariables' : function(){
-		var dataSourceVariables = this.model.get('dataSourceVariables');
-		var plainObjects = _.pluck(dataSourceVariables.models, 'attributes');
-		this.selectMenuView.updateMenuOptions(plainObjects);
-	},
-	'changeInvalidUrl' : function(){
-		var invalidUrl = this.model.get('invalidDataSourceUrl');
-		var selectorsToToggleDisabled = [
-			datePickers.start.selector,
-			datePickers.end.selector,
-			variablePicker.selector
-		];
-
-		_.each(selectorsToToggleDisabled, function(selector){
-			$(selector).prop('disabled', invalidUrl);
-		});
-	},
-	/**
-	 * Reacts to a change in url
-	 *
-	 * @returns {jQuery.Deferred.promise} The promise is resolved with no args
-	 * if user cleared the url or if user submitted a url and all subsequent
-	 * web service calls succeded. The promise is rejected with an error message
-	 * if any web service calls fail, or if the web service responses cannot be
-	 * parsed.
-	 */
-	'changeUrl': function () {
-		var self = this,
-		url = this.model.get('dataSourceUrl'),
-		deferred = $.Deferred();
-		if (!(_.isNull(url) || _.isUndefined(url) || _.isEmpty(url))) {
-			this.getGrids(url).done(function(catalogUrl, gridName){
-				var dateRangePromise = self.getDateRange(catalogUrl, gridName);
-				dateRangePromise.then(function(){
-					deferred.resolve.apply(this, arguments);
-				}, function(){
-					deferred.reject.apply(this, arguments);
-				});
-			}).fail(function(){
-				deferred.reject.apply(this, arguments);
-			});
-		} else {
-			//user is just clearing the url, no need for web service calls
-			deferred.resolve();
-		}
-		self.model.set('invalidDataSourceUrl', true);
-		self.model.get('dataSourceVariables').reset();
-		self.resetDates();
-		return deferred.promise();
-	},
-	'failedToParseVariableResponseMessage' : "No variables were discovered at this data source url.",
-	'isValidGridResponse' : function(response){
-		var isValid = false;
-		//if response.datatypecollection.types is present
-		if(response && response.datatypecollection && response.datatypecollection.types){
-			//and if response.datatypecollection.types is an object or a non-zero-length array
-			if(response.datatypecollection.types.length || $.isPlainObject(response.datatypecollection.types)){
-				isValid = true;
-			}
-		}
-		return isValid;
-	},
-	/**
-	 * Gets the variables present in a url.
-	 *
-	 * @param {String} dataSourceUrl
-	 * @returns {jQuery.Deferred.promise} The promise is resolved with args
-	 * ({String} data source url, {String} variable name) when the web service call
-	 * succeeds. The promise is rejected with one arg ({String} error message)
-	 * if the web service calls fail or their responses cannot be parsed.
-	 */
-	'getGrids': function (dataSourceUrl) {
-		var self = this,
-				variables =[],
-				deferred = $.Deferred(),
-				wpsInputs = {
-					"catalog-url": [dataSourceUrl],
-					"allow-cached-response": [$('#use-cached-checkbox').is(':checked')]
-				},
-				wpsOutput = ["result_as_json"];
-
-		this.wps.sendWpsExecuteRequest(
-				this.wpsEndpoint + '/WebProcessingService',
-				VARIABLE_WPS_PROCESS_ID,
-				wpsInputs,
-				wpsOutput,
-				false,
-				null,
-				true,
-				'json',
-				'application/json'
-				)
-			.done(function (response, textStatus, message) {
-				var invalidUrl = true;
-				if (self.isValidGridResponse(response)) {
-					if(!response.datatypecollection.types.length){
-						response.datatypecollection.types = [response.datatypecollection.types];
-					}
-					variables = _.map(response.datatypecollection.types, function (type) {
-						var text = type.name + ' - ' + type.description + ' (' + type.unitsstring + ")";
-						var value = type.name;
-						return {
-							'text': text,
-							'value': value,
-							'selected': false
-						};
-					});
-					invalidUrl = false;
-					deferred.resolve(dataSourceUrl, variables[0].value);
-				}
-				else {
-					//todo: anything better than 'alert'
-					var message = self.failedToParseVariableResponseMessage;
-					alert(message);
-					deferred.reject(message);
-				}
-				self.model.get('dataSourceVariables').reset(variables);
-				self.model.set('invalidDataSourceUrl', invalidUrl);
-			}).fail(function (jqxhr, textStatus, message) {
-				//todo: anything better than 'alert'
-				alert(message);
-				self.model.set('invalidDataSourceUrl', true);
-				self.model.get('dataSourceVariables').reset();
-				deferred.reject(message);
-			}).always(function () {
-			});
-			return deferred.promise();
-	},
-	'hasExpectedNumericProperties' : function(obj, expectedProperties){
-		var hasExpectedNumericProperties = true;
-		if (_.isObject(obj)) {
-			var picked = _.pick(obj, expectedProperties);
-			if(_.keys(picked).length !== expectedProperties.length){
-				hasExpectedNumericProperties = false;
-			}
-			else {
-				var valuesAreNumeric = _.chain(picked).values().every(_.isNumber).value();
-				if(!valuesAreNumeric){
-					hasExpectedNumericProperties = false;
-				}
-			}
-		}
-		else{
-			hasExpectedNumericProperties = false;
-		}
-		return hasExpectedNumericProperties;
-	},
-	'isValidDateRangeResponse' : function(response){
-		var expectedProperties = ['year','month','day'],
-		hasAvailableTimes = false,
-		validStartTime = false,
-		validEndTime = false,
-		isDefined = !!response;
-		if(isDefined){
-			hasAvailableTimes = !!response.availabletimes;
-			if(hasAvailableTimes){
-				validStartTime = this.hasExpectedNumericProperties(response.availabletimes.starttime, expectedProperties),
-				validEndTime = this.hasExpectedNumericProperties(response.availabletimes.endtime, expectedProperties);
-			}
-		}
-		return isDefined && hasAvailableTimes && validStartTime && validEndTime;
-	},
-	'failedToParseDateRangeResponseMessage' : 'Could not determine date range for selected data source',
-	/**
-	 * Retrieves the date range for a given data source and variable. Updates
-	 * the model with the retrieved values.
-	 *
-	 * @param {String} dataSourceUrl
-	 * @param {String} variableName
-	 * @returns {jQuery.Deferred.promise} The promise is resolved with no args
-	 * when the web service call completes successfully. The promise is rejected
-	 * with an error message if the web service calls fail or the responses
-	 * cannot be parsed.
-	 */
-	'getDateRange': function(dataSourceUrl, variableName){
-		var self = this,
-			deferred = $.Deferred(),
-			wpsInputs = {
-				"catalog-url": [dataSourceUrl],
-				"allow-cached-response": [$('#use-cached-checkbox').is(':checked')],
-				"grid": [variableName]
-			},
-			wpsOutput = ["result_as_json"];
-
-		this.wps.sendWpsExecuteRequest(
-			this.wpsEndpoint + '/WebProcessingService',
-			DATE_RANGE_WPS_PROCESS_ID,
-			wpsInputs,
-			wpsOutput,
-			false,
-			null,
-			true,
-			'json',
-			'application/json'
-		).done(function (response, textStatus, message) {
-			var minDate,
-				maxDate,
-				invalid = true;
-			if (self.isValidDateRangeResponse(response)){
-				var minObj = response.availabletimes.starttime,
-					maxObj = response.availabletimes.endtime;
-				//service month index is 1-based. JS month index is 0-based
-				minDate = new Date(minObj.year, minObj.month - 1, minObj.day);
-				maxDate = new Date(maxObj.year, maxObj.month -1, maxObj.day);
-				invalid = false;
-			}
-			else {
-				//todo: anything better than 'alert'
-				var message = self.failedToParseDateRangeResponseMessage;
-				alert(message);
-				deferred.reject(message);
-			}
-			self.model.set('minDate', minDate);
-			self.model.set('startDate', minDate);
-			self.model.set('maxDate', maxDate);
-			self.model.set('endDate', maxDate);
-			self.model.set('invalidDataSourceUrl', invalid);
-			deferred.resolve();
-		}).fail(function (jqxhr, textStatus, message) {
-			//todo: anything better than 'alert'
-			alert(message);
-			self.model.set('minDate', null);
-			self.model.set('maxDate', null);
-			self.model.set('invalidDataSourceUrl', true);
-			deferred.reject(message);
-		}).always(function () {
-		});
-		return deferred.promise();
+		this.model.set('dataSourceVariables', this.$(variablePicker.selector).val());
 	}
 });
 

--- a/src/main/webapp/js/process_client/views/DataDetailsView.js
+++ b/src/main/webapp/js/process_client/views/DataDetailsView.js
@@ -25,257 +25,261 @@ var GDP = GDP || {};
 	};
 
     GDP.PROCESS_CLIENT.view.DataDetailsView = GDP.util.BaseView.extend({
-	'events' : (function(){
-		var ret = {};
-		ret['change ' + variablePicker.selector] = 'setSelectedVariables';
-		ret['change ' + urlTextPicker.selector] = 'setUrl';
-		ret['change ' + dataSourcePicker.selector] = 'setUrl';
-		ret['changeDate ' + datePickers.start.selector] = 'setStartDate';
-		ret['changeDate ' + datePickers.end.selector] = 'setEndDate';
-		ret['submit form'] = 'goToHubPage';
-		return ret;
-	}()),
+		'events' : (function(){
+			var ret = {};
+			ret['change ' + variablePicker.selector] = 'setSelectedVariables';
+			ret['change ' + urlTextPicker.selector] = 'setUrl';
+			ret['change ' + dataSourcePicker.selector] = 'setUrl';
+			ret['changeDate ' + datePickers.start.selector] = 'setStartDate';
+			ret['changeDate ' + datePickers.end.selector] = 'setEndDate';
+			ret['submit form'] = 'goToHubPage';
+			return ret;
+		}()),
 
-	getDataSourceOptions : function() {
-		var dataSourceUrl = this.model.get('dataSourceUrl');
-		var dataSources = this.model.get('dataSetModel').get('dataSources');
+		getDataSourceOptions : function() {
+			var dataSourceUrl = this.model.get('dataSourceUrl');
+			var dataSources = this.model.get('dataSetModel').get('dataSources');
 
-		return _.map(dataSources, function(dataSource) {
-			return {
-				text : dataSource.title,
-				value : dataSource.url,
-				selected : dataSource.url === dataSourceUrl
-			};
-		});
-	},
-
-	getVariableOptions : function() {
-		var dataVariables = this.model.get('dataVariables');
-		var variableCollection = this.model.get('dataSourceModel').get('variables');
-		return _.map(variableCollection.models, function(variableModel){
-			var varAttributes = variableModel.attributes;
-			return {
-				text : varAttributes.name + ' - ' + varAttributes.description + ' (' + varAttributes.unitsstring + ")",
-				value : varAttributes.name,
-				selected : _.contains(dataVariables, varAttributes.name)
-			};
-		});
-	},
-
-	/*
-	 *
-	 * @param {Object} options
-	 *     @prop {Function} template - returns a function which will render the template for this view
-	 *     @prop {GDP.PROCESS_CLIENT.JobModel} model
-	 *     @prop {String} datasetId,
-	 */
-	'initialize': function(options) {
-		var self = this;
-		//Fetch data set model
-		var getDataSetModelPromise = this.model.updateDataSetModel(options.datasetId);
-		var hasVariables = this.model.get('dataSourceModel').get('variables').length > 0;
-
-		this.routePrefix = options.datasetId ? '#!catalog/gdp/dataset/' + options.datasetId : '#!advanced';
-
-		this.context = this.model.attributes;
-		this.context.hasDataSources = options.datasetId;
-
-		//super
-		GDP.util.BaseView.prototype.initialize.apply(self, arguments);
-
-		if (options.datasetId) {
-			this.dataSourceSelectMenuView = new GDP.util.SelectMenuView({
-				sortBy : 'text',
-				emptyPlaceholder : true,
-				menuOptions : this.getDataSourceOptions(),
-				el : '#data-source-select'
+			return _.map(dataSources, function(dataSource) {
+				return {
+					text : dataSource.title,
+					value : dataSource.url,
+					selected : dataSource.url === dataSourceUrl
+				};
 			});
-		}
+		},
 
-		this.variablesSelectMenuView = new GDP.util.SelectMenuView({
-				el : variablePicker.selector,
-				emptyPlaceholder : false,
-				sortOptions: false,
-				menuOptions : this.getVariableOptions()
-		});
-		if (hasVariables) {
-			this.$(variablePicker.selector).prop('disabled', !hasVariables);
-		}
-
-		getDataSetModelPromise.done(function() {
-			var dataSourceModel = self.model.get('dataSourceModel');
-
-			self.listenTo(self.model, 'change:dataSourceUrl', self.changeUrl);
-			self.listenTo(dataSourceModel, 'change:variables', self.updateVariables);
-			self.listenTo(dataSourceModel, 'change:dateRange', self.changeDateRange);
-			self.listenTo(self.model, 'change:dataVariables', self.changeVariables);
-			self.listenTo(self.model, 'change:startDate', self.changeStartDate);
-			self.listenTo(self.model, 'change:endDate', self.changeEndDate);
-
-			self.dataSourceSelectMenuView.updateMenuOptions(self.getDataSourceOptions());
-			self.updateVariables();
-			self.changeVariables();
-
-			self.changeStartDate();
-			self.changeEndDate();
-
-			// Set datePickers start and end dates
-			self.updateStartEndDates(dataSourceModel.get('dateRange'));
-		});
-	},
-	'setEndDate' : function(ev){
-		ev.preventDefault();
-		this.model.set('endDate', ev.target.value);
-	},
-	'setStartDate' : function(ev){
-		ev.preventDefault();
-		this.model.set('startDate', ev.target.value);
-	},
-	'setUrl' : function(ev){
-		this.model.set('dataSourceUrl', ev.target.value);
-	},
-	/*
-	 * Route back to the hub page.
-	 * @param {Jquery event} ev
-	 * @returns {undefined}
-	 */
-	goToHubPage : function(ev) {
-		ev.preventDefault();
-		this.router.navigate(this.routePrefix, {trigger : true});
-	},
-
-	setInputsDisabled : function(disabled) {
-		this.$(urlTextPicker.selector).prop('disabled', disabled);
-		this.$(dataSourcePicker.selector).prop('disabled', disabled);
-		this.$(variablePicker.selector).prop('disabled', disabled);
-		this.$(datePickers.start.selector).prop('disabled', disabled);
-		this.$(datePickers.end.selector).prop('disabled', disabled);
-	},
-
-	changeUrl : function() {
-		var self = this;
-		var dataSourceUrl = this.model.get('dataSourceUrl');
-		var dataSourceModel = this.model.get('dataSourceModel');
-
-		this.$(dataSourcePicker.selector).val(dataSourceUrl);
-		this.$(urlTextPicker.selector).val(dataSourceUrl);
-
-		if (dataSourceUrl) {
-			this.setInputsDisabled(true);
-
-			dataSourceModel.fetch({
-				dataSourceUrl : dataSourceUrl,
-				allowCache : this.$('#use-cached-checkbox').is(':checked')
-			}).fail(function(msg) {
-				self.model.set('dataVariable', []);
-				self.model.set('startDate', '');
-				self.model.set('endDate', '');
-				//TODO: better error handling
-				GDP.logger.debug(msg);
-				window.alert(msg);
-			}).always(function() {
-				self.setInputsDisabled(false);
+		getVariableOptions : function() {
+			var dataVariables = this.model.get('dataVariables');
+			var variableCollection = this.model.get('dataSourceModel').get('variables');
+			return _.map(variableCollection.models, function(variableModel){
+				var varAttributes = variableModel.attributes;
+				return {
+					text : varAttributes.name + ' - ' + varAttributes.description + ' (' + varAttributes.unitsstring + ")",
+					value : varAttributes.name,
+					selected : _.contains(dataVariables, varAttributes.name)
+				};
 			});
+		},
+
+		/*
+		 *
+		 * @param {Object} options
+		 *     @prop {Function} template - returns a function which will render the template for this view
+		 *     @prop {GDP.PROCESS_CLIENT.JobModel} model
+		 *     @prop {String} datasetId,
+		 */
+		'initialize': function(options) {
+			var self = this;
+			//Fetch data set model
+			var getDataSetModelPromise = this.model.updateDataSetModel(options.datasetId);
+			var hasVariables = this.model.get('dataSourceModel').get('variables').length > 0;
+
+			this.routePrefix = options.datasetId ? '#!catalog/gdp/dataset/' + options.datasetId : '#!advanced';
+
+			this.context = this.model.attributes;
+			this.context.hasDataSources = options.datasetId;
+
+			//super
+			GDP.util.BaseView.prototype.initialize.apply(self, arguments);
+
+			if (options.datasetId) {
+				this.dataSourceSelectMenuView = new GDP.util.SelectMenuView({
+					sortBy : 'text',
+					emptyPlaceholder : true,
+					menuOptions : this.getDataSourceOptions(),
+					el : '#data-source-select'
+				});
+			}
+
+			this.variablesSelectMenuView = new GDP.util.SelectMenuView({
+					el : variablePicker.selector,
+					emptyPlaceholder : false,
+					sortOptions: false,
+					menuOptions : this.getVariableOptions()
+			});
+			if (hasVariables) {
+				this.$(variablePicker.selector).prop('disabled', !hasVariables);
+			}
+
+			getDataSetModelPromise.done(function() {
+				var dataSourceModel = self.model.get('dataSourceModel');
+
+				self.listenTo(self.model, 'change:dataSourceUrl', self.changeUrl);
+				self.listenTo(dataSourceModel, 'change:variables', self.updateVariables);
+				self.listenTo(dataSourceModel, 'change:dateRange', self.changeDateRange);
+				self.listenTo(self.model, 'change:dataVariables', self.changeVariables);
+				self.listenTo(self.model, 'change:startDate', self.changeStartDate);
+				self.listenTo(self.model, 'change:endDate', self.changeEndDate);
+
+				if (_.has(self, 'dataSourceSelectMenuView')) {
+					self.dataSourceSelectMenuView.updateMenuOptions(self.getDataSourceOptions());
+				}
+				self.updateVariables();
+				self.changeVariables();
+
+				self.changeStartDate();
+				self.changeEndDate();
+
+				// Set datePickers start and end dates
+				self.updateStartEndDates(dataSourceModel.get('dateRange'));
+			});
+		},
+
+		/*
+		 * Route back to the hub page.
+		 * @param {Jquery event} ev
+		 * @returns {undefined}
+		 */
+		goToHubPage : function(ev) {
+			ev.preventDefault();
+			this.router.navigate(this.routePrefix, {trigger : true});
+		},
+
+		setInputsDisabled : function(disabled) {
+			this.$(urlTextPicker.selector).prop('disabled', disabled);
+			this.$(dataSourcePicker.selector).prop('disabled', disabled);
+			this.$(variablePicker.selector).prop('disabled', disabled);
+			this.$(datePickers.start.selector).prop('disabled', disabled);
+			this.$(datePickers.end.selector).prop('disabled', disabled);
+		},
+
+		changeUrl : function() {
+			var self = this;
+			var dataSourceUrl = this.model.get('dataSourceUrl');
+			var dataSourceModel = this.model.get('dataSourceModel');
+
+			this.$(dataSourcePicker.selector).val(dataSourceUrl);
+			this.$(urlTextPicker.selector).val(dataSourceUrl);
+
+			if (dataSourceUrl) {
+				this.setInputsDisabled(true);
+
+				dataSourceModel.fetch({
+					dataSourceUrl : dataSourceUrl,
+					allowCached : this.$('#use-cached-checkbox').is(':checked')
+				}).fail(function(msg) {
+					self.model.set('dataVariable', []);
+					self.model.set('startDate', '');
+					self.model.set('endDate', '');
+					//TODO: better error handling
+					GDP.logger.debug(msg);
+					window.alert(msg);
+				}).always(function() {
+					self.setInputsDisabled(false);
+				});
+			}
+			else {
+				this.model.set('dataVariable', []);
+				this.model.set('startDate', '');
+				this.model.set('endDate', '');
+			}
+		},
+
+		updateVariables : function() {
+			var dataSourceModel = this.model.get('dataSourceModel');
+			var variables = dataSourceModel.get('variables');
+			var $variablePicker = this.$(variablePicker.selector);
+			this.variablesSelectMenuView.updateMenuOptions(this.getVariableOptions());
+			$variablePicker.prop('disabled', !variables.length);
+		},
+
+		updateStartEndDates : function(dateRange) {
+			var $startDate = this.$(datePickers.start.selector);
+			var $endDate = this.$(datePickers.end.selector);
+
+			if (dateRange.start) {
+				$startDate.datepicker('setStartDate', dateRange.start);
+				$startDate.datepicker('setEndDate', dateRange.end);
+			}
+
+			if (dateRange.end) {
+				$endDate.datepicker('setStartDate', dateRange.start);
+				$endDate.datepicker('setEndDate', dateRange.end);
+			}
+		},
+
+		changeDateRange : function() {
+			var dateRange = this.model.get('dataSourceModel').get('dateRange');
+			var $startDate = this.$(datePickers.start.selector);
+			var $endDate = this.$(datePickers.end.selector);
+
+			$startDate.prop('disabled', !dateRange.start);
+			$endDate.prop('disabled', !dateRange.end);
+
+			this.updateStartEndDates(dateRange);
+
+			this.model.set('startDate', dateRange.start);
+			this.model.set('endDate', dateRange.end);
+		},
+
+		changeVariables : function() {
+			this.$(variablePicker.selector).val(this.model.get('dataVariables'));
+		},
+
+		'changeStartDate' : function(){
+			var startDate = this.model.get('startDate');
+			var $startDate = this.$(datePickers.start.selector);
+
+			if ('' === startDate){
+				$startDate.datepicker('clearDates');
+			}
+			else{
+				this.$(datePickers.end.selector).datepicker('setStartDate', startDate);
+				$startDate.datepicker('setDate', startDate);
+			}
+		},
+		'changeEndDate' : function(){
+			var endDate = this.model.get('endDate');
+			var $endDate = this.$(datePickers.end.selector);
+
+			if('' === endDate){
+				$endDate.datepicker('clearDates');
+			}
+			else{
+				this.$(datePickers.start.selector).datepicker('setEndDate', endDate);
+				$endDate.datepicker('setDate', endDate);
+			}
+		},
+
+		'render' : function () {
+			this.$el.html(this.template(this.context));
+			this.selectMenuView = new GDP.util.SelectMenuView({
+					el : variablePicker.selector,
+					emptyPlaceholder : false,
+					sortOptions: false
+			});
+			this.$(datePickers.start.selector).datepicker({
+				format : 'm/d/yyyy'
+			});
+			this.$(datePickers.end.selector).datepicker({
+				format : 'm/d/yyyy'
+			});
+			return this;
+		},
+
+		remove : function() {
+			if (_.has(this, 'dataSourceSelectMenuView')) {
+				this.dataSourceSelectMenuView.remove();
+			}
+			this.variablesSelectMenuView.remove();
+			GDP.util.BaseView.prototype.remove.apply(this, arguments);
+
+		},
+		'setEndDate' : function(ev){
+			ev.preventDefault();
+			this.model.set('endDate', ev.target.value);
+		},
+		'setStartDate' : function(ev){
+			ev.preventDefault();
+			this.model.set('startDate', ev.target.value);
+		},
+		'setUrl' : function(ev){
+			this.model.set('dataSourceUrl', ev.target.value);
+		},
+		'setSelectedVariables' : function (ev) {
+			this.model.set('dataVariables', _.pluck(ev.target.selectedOptions, 'value'));
 		}
-		else {
-			this.model.set('dataVariable', []);
-			this.model.set('startDate', '');
-			this.model.set('endDate', '');
-		}
-	},
-
-	updateVariables : function() {
-		var dataSourceModel = this.model.get('dataSourceModel');
-		var variables = dataSourceModel.get('variables');
-		var $variablePicker = this.$(variablePicker.selector);
-		this.variablesSelectMenuView.updateMenuOptions(this.getVariableOptions());
-		$variablePicker.prop('disabled', !variables.length);
-	},
-
-	updateStartEndDates : function(dateRange) {
-		var $startDate = this.$(datePickers.start.selector);
-		var $endDate = this.$(datePickers.end.selector);
-
-		if (dateRange.start) {
-			$startDate.datepicker('setStartDate', dateRange.start);
-			$startDate.datepicker('setEndDate', dateRange.end);
-		}
-
-		if (dateRange.end) {
-			$endDate.datepicker('setStartDate', dateRange.start);
-			$endDate.datepicker('setEndDate', dateRange.end);
-		}
-	},
-
-	changeDateRange : function() {
-		var dateRange = this.model.get('dataSourceModel').get('dateRange');
-		var $startDate = this.$(datePickers.start.selector);
-		var $endDate = this.$(datePickers.end.selector);
-
-		$startDate.prop('disabled', !dateRange.start);
-		$endDate.prop('disabled', !dateRange.end);
-
-		this.updateStartEndDates(dateRange);
-
-		this.model.set('startDate', dateRange.start);
-		this.model.set('endDate', dateRange.end);
-	},
-
-	changeVariables : function() {
-		this.$(variablePicker.selector).val(this.model.get('dataVariables'));
-	},
-
-	'changeStartDate' : function(){
-		var startDate = this.model.get('startDate');
-		var $startDate = this.$(datePickers.start.selector);
-
-		if ('' === startDate){
-			$startDate.datepicker('clearDates');
-		}
-		else{
-			this.$(datePickers.end.selector).datepicker('setStartDate', startDate);
-			$startDate.datepicker('setDate', startDate);
-		}
-	},
-	'changeEndDate' : function(){
-		var endDate = this.model.get('endDate');
-		var $endDate = this.$(datePickers.end.selector);
-
-		if('' === endDate){
-			$endDate.datepicker('clearDates');
-		}
-		else{
-			this.$(datePickers.start.selector).datepicker('setEndDate', endDate);
-			$endDate.datepicker('setDate', endDate);
-		}
-	},
-
-	'render' : function () {
-		this.$el.html(this.template(this.context));
-		this.selectMenuView = new GDP.util.SelectMenuView({
-				el : variablePicker.selector,
-				emptyPlaceholder : false,
-				sortOptions: false
-		});
-		this.$(datePickers.start.selector).datepicker({
-			format : 'm/d/yyyy'
-		});
-		this.$(datePickers.end.selector).datepicker({
-			format : 'm/d/yyyy'
-		});
-		return this;
-	},
-
-	remove : function() {
-		this.dataSourceSelectMenuView.remove();
-		this.variablesSelectMenuView.remove();
-		GDP.util.BaseView.prototype.remove.apply(this, arguments);
-
-	},
-
-	'setSelectedVariables' : function (ev) {
-		this.model.set('dataVariables', this.$(variablePicker.selector).val());
-	}
-});
+	});
 
 }(_, jQuery));

--- a/src/main/webapp/js/process_client/views/HubView.js
+++ b/src/main/webapp/js/process_client/views/HubView.js
@@ -234,6 +234,8 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 							emailWPSInputs.filename = [filename];
 						}
 
+						if (self.model.get)
+
 						GDP.wpsClient.sendWpsExecuteRequest(
 							GDP.config.get('application').endpoints.utilityWps + '/WebProcessingService',
 							self.EMAIL_WHEN_FINISHED_ALGORITHM,

--- a/src/main/webapp/js/process_client/views/HubView.js
+++ b/src/main/webapp/js/process_client/views/HubView.js
@@ -45,14 +45,12 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 		 * @param {Object} -
 		 *      @prop {Function} template - page template function
 		 *      @prop {Function} metadataTemplate - template to be used to render the metadat tile contents
-		 *      @prop {Function} wps - instance of the GDP.OGC.wps function
 		 *      @prop {Object} model - instance of GDP.PROCESS_CLIENT.model.JobModel
 		 *      @prop {String} datasetId - can be null .
 		 */
 
 		initialize : function(options) {
 			var self = this;
-			this.wps = options.wps;
 			this.routePrefix = options.datasetId ? '#!catalog/gdp/dataset/' + options.datasetId  : '#!advanced';
 
 			GDP.util.BaseView.prototype.initialize.apply(this, arguments);
@@ -158,14 +156,14 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 				// We now have all the information we need to get started
 				self.childViews.alertView.show('alert-info', 'Process status: started');
 
-				executePromise = self.wps.sendWpsExecuteRequest(
+				executePromise = GDP.wpsClient.sendWpsExecuteRequest(
 					GDP.config.get('application').endpoints.processWps + '/WebProcessingService',
 					self.model.get('algorithmId'),
 					wpsStringInputs,
 					['OUTPUT'],
 					true,
 					{
-						'FEATURE_COLLECTION' : [self.wps.createWfsWpsReference(GDP.config.get('application').serviceEndpoints.wfs, xmlInputs)]
+						'FEATURE_COLLECTION' : [GDP.wpsClient.createWfsWpsReference(GDP.config.get('application').serviceEndpoints.wfs, xmlInputs)]
 					},
 					false,
 					'xml',
@@ -236,7 +234,7 @@ GDP.PROCESS_CLIENT.view = GDP.PROCESS_CLIENT.view || {};
 							emailWPSInputs.filename = [filename];
 						}
 
-						self.wps.sendWpsExecuteRequest(
+						GDP.wpsClient.sendWpsExecuteRequest(
 							GDP.config.get('application').endpoints.utilityWps + '/WebProcessingService',
 							self.EMAIL_WHEN_FINISHED_ALGORITHM,
 							emailWPSInputs,

--- a/src/main/webapp/templates/datadetail.html
+++ b/src/main/webapp/templates/datadetail.html
@@ -3,13 +3,10 @@
 	<div class="col-sm-12" id="messages-div"></div>	
 	<form class="panel-body">
 		<div class="form-group">
-			{{#if dataSources}}
+			{{#if hasDataSources}}
 			<label for="data-source-select">Data Source</label>
 			<select id="data-source-select" class="form-control" required>
 				<option></option>
-				{{#each dataSources}}
-				<option value="{{this.url}}" {{defaultSelected this.url ../dataSourceUrl}}>{{this.title}}</option>
-				{{/each}}
 			</select>
 			{{else}}
 			<label for="data-source-url">Data Source URL</label>
@@ -29,9 +26,9 @@
 		<div class="form-horizontal">
 			<div class="form-group input-daterange">
 				<label for="start-date">Date Range</label>
-				<input id="start-date" class="form-control" type="text" required disabled/>
+				<input id="start-date" class="form-control" type="text" required {{#if startDate}}{{else}}disabled{{/if}} value="{{startDate}}"/>
 				<label for="end-date">to</label>
-				<input id="end-date" class="form-control" type="text" required disabled/>
+				<input id="end-date" class="form-control" type="text" required {{#if endDate}}{{else}}disabled{{/if}} value="{{endDate}}"/>
 			</div>
 		</div>
 		<div class="row center-block">

--- a/src/main/webapp/templates/hub.html
+++ b/src/main/webapp/templates/hub.html
@@ -51,7 +51,7 @@
 					</div>
 					<h5>Number of Selected Variables</h5>
 					<div class="selected-option">
-						{{selectedVariables jobModel.dataSourceVariables.models}}
+						{{jobModel.dataVariables.length}}&nbsp;
 					</div>
 					<h5>Date Range</h5>
 					<div class="selected-option">

--- a/src/test/js/specs/DataDetailsView_spec.js
+++ b/src/test/js/specs/DataDetailsView_spec.js
@@ -1,5 +1,5 @@
 /*jslint browser: true*/
-/*global sinon,Backbone,jasmine,expect,GDP,_,expect,window*/
+/*global sinon,Backbone,jasmine,expect,GDP,_,expect,window, spyOn*/
 describe('GDP.PROCESS_CLIENT.view.DataDetailsView', function() {
 	var model,
 	templateSpy,
@@ -7,37 +7,16 @@ describe('GDP.PROCESS_CLIENT.view.DataDetailsView', function() {
 	loggerSpy,
 	server,
 	testView,
-	callWpsSpy,
-	wpsDeferred,
-	wps,
-	updateDataSetModelDeferred,
-	url = 'http://cida.usgs.gov';
+	url,
+	dataSourceModel,
+	dataSourceFetchDeferred,
+	updateDataSetModelDeferred;
 
 	//no-op alert
 	window.alert = function(){};
 
-	//mock promises for patching
-	var resolveWithResponse = function(response){
-		return function(){
-			var deferred = $.Deferred();
-			deferred.resolve(response);
-			return deferred.promise();
-		};
-	};
-
-	var rejectWithErrorMessage = function(message){
-		return function(){
-			var deferred = $.Deferred();
-			deferred.reject(null, null, message);
-			return deferred.promise();
-		};
-	};
-
 	beforeEach(function() {
-		server = sinon.fakeServer.create();
-
-		updateDataSetModelDeferred = $.Deferred();
-
+		url = 'http://testUrl';
 		GDP.config = {
 			get : function(prop) {
 				if (prop === 'process') {
@@ -70,298 +49,43 @@ describe('GDP.PROCESS_CLIENT.view.DataDetailsView', function() {
 			}
 		};
 		model = new GDP.PROCESS_CLIENT.model.Job();
+		updateDataSetModelDeferred = $.Deferred();
 		spyOn(model, 'updateDataSetModel').andReturn(updateDataSetModelDeferred);
+		dataSourceModel = model.get('dataSourceModel');
+		dataSourceFetchDeferred = $.Deferred();
+		spyOn(dataSourceModel, 'fetch').andReturn(dataSourceFetchDeferred);
 
-		wpsDeferred = $.Deferred();
 
 		templateSpy = jasmine.createSpy('templateSpy');
-		renderSpy = jasmine.createSpy('renderSpy');
 		loggerSpy = jasmine.createSpyObj('logger', ['error']);
-		callWpsSpy = jasmine.createSpy('callWpsSpy').andReturn(wpsDeferred);
 
 		GDP.logger = loggerSpy;
-		wps = {
-			sendWpsExecuteRequest : callWpsSpy
-		};
 
 		testView = new GDP.PROCESS_CLIENT.view.DataDetailsView({
 			model : model,
 			template : templateSpy,
-			wps: wps
 		});
-		testView.render = renderSpy;
+		updateDataSetModelDeferred.resolve();
 	});
 
-	afterEach(function() {
-		server.restore();
-	});
 	it('Expects setUrl() to change the model\'s dataSourceUrl property', function() {
 		testView.setUrl({ target : { value : url } });
 		expect(testView.model.get('dataSourceUrl')).toEqual(url);
 	});
 
 	it('Expects setSelectedVariables() to change the model\'s dataSourceVariables property', function() {
-		var options = [
-			{
-			text: '',
-			value: '',
-			selected: null
-			},
-			{
-			text: 'Var One',
-			value: 'var1',
-			selected: 'selected'
-			},
-			{
-			text: 'Var Two',
-			value: 'var2',
-			selected: ''
-			}
-		];
-
-		//call the function with 0, 1, 2, and 3 options.
-		_.each(_.range(options.length), function(numberOfOptions){
-			var optionsToUse = _.first(options, numberOfOptions);
-			testView.setSelectedVariables({ target : {options: optionsToUse }});
-			var selectedOptions= testView.model.get('dataSourceVariables');
-			var expectedToActualPairs = _.zip(optionsToUse, selectedOptions.models);
-			_.each(expectedToActualPairs, function(expectedToActual){
-				var expected = expectedToActual[0],
-					actual = expectedToActual[1].attributes;
-				expect(expected).toEqual(actual);
-			});
-		});
-	});
-	it('should reject the getDateRange promise with an error message if the web service call fails', function(){
-		var expectedErrorMessage = 'error message';
-		testView.wps.sendWpsExecuteRequest = rejectWithErrorMessage(expectedErrorMessage);
-		var promise, actualErrorMessage;
-		runs(function(){
-			promise = testView.getDateRange('mockUrl', 'mockVariableName').fail(function(myMessage){
-				actualErrorMessage = myMessage;
-			});
-		});
-		waitsFor(function(){
-			return 'pending' !== promise.state();
-		});
-		runs(function(){
-			expect(actualErrorMessage).toBe(expectedErrorMessage);
-		});
-	});
-	it('hasExpectedNumericProperties should return true if an object has all expected properties and all the corresponding values are numeric, and false otherwise', function(){
-		var expectedProperties = ['a', 'b'];
-		var failingValues = [
-			//not an object
-			null,
-
-			//empty object
-			{},
-
-			//object with only a some of the expected properties
-			{
-				'a': null,
-				'c': null
-			},
-			//object with all expected properties, but no values are numeric
-			{
-				'a': 'not a num',
-				'b': [],
-				'c': {}
-			}
-		],
-
-		//object with all expected properties and all numeric values
-		passingValue = {
-			'a': 42,
-			'b': 3.14159,
-			'c': {}
-		};
-		_.each(failingValues, function(failingValue){
-			expect(testView.hasExpectedNumericProperties(failingValue, expectedProperties)).toBe(false);
-		});
-		expect(testView.hasExpectedNumericProperties(passingValue, expectedProperties)).toBe(true);
-	});
-	it('isValidDateRangeResponse should return true if a response is a valid date range response, and false otherwise', function(){
-		var unparseableResponses = [
-			null,
-			undefined,
-			false,
-			200,
-			'',
-			{},
-			{availabletimes:null},
-			{
-				availabletimes:{
-					starttime: null
-				}
-			},
-			{
-				availabletimes:{
-					starttime: null,
-					endtime: null
-				}
-			},
-			{
-				availabletimes:{
-					endtime: null
-				}
-			}
-		];
-		_.each(unparseableResponses, function(unparseableResponse){
-			expect(testView.isValidDateRangeResponse(unparseableResponse)).toBe(false);
-		});
-		var validResponse = {
-			availabletimes:{
-				starttime: {
-					year: 2001,
-					month: 1,
-					day: 1
-				},
-				endtime:{
-					year: 2002,
-					month: 2,
-					day: 2
-				}
+		var ev = {
+			target : {
+				selectedOptions : [
+					{
+						value : 'var1'
+					}, {
+						value : 'var2'
+					}
+				]
 			}
 		};
-		expect(testView.isValidDateRangeResponse(validResponse)).toBe(true);
-	});
-	it('expects the getDateRange() promise to be rejected with an error message if the web service call succeeds, but delivers an unparseable response', function(){
-		var promise, returnedMessage;
-
-		//mocks
-		testView.isValidDateRangeResponse = function(){return false;};
-		testView.wps.sendWpsExecuteRequest = resolveWithResponse(null);
-
-		runs(function(){
-			promise = testView.getDateRange('mockUrl', 'mockVariableName').fail(function(myMessage){
-				returnedMessage = myMessage;
-			});
-		});
-		waitsFor(function(){
-			return 'pending' !== promise.state();
-		});
-		runs(function(){
-			expect(returnedMessage).toBe(testView.failedToParseDateRangeResponseMessage);
-		});
-	});
-	var assertDatesReset = function(testView){
-		var datesAreReset = _.every(_.map(testView.dateModelProperties, function(modelProp){
-				return testView.model.get(modelProp);
-		}), _.isNull);
-		expect(datesAreReset).toBe(true);
-	};
-	it('expects resetDates() to set all date relevant date fields on the model to null', function(){
-		assertDatesReset(testView);
-	});
-	var assertDataDetailFieldsReset = function(testView){
-		assertDatesReset(testView);
-		expect(testView.model.get('dataSourceVariables').isEmpty()).toBe(true);
-		expect(testView.model.get('invalidDataSourceUrl')).toBe(true);
-	};
-	it('expects changeUrl() to initially reset all relevant model fields', function(){
-		testView.getGrids = rejectWithErrorMessage('no-op');
-		var actualUrl = 'http://cida.usgs.gov';
-		var mockModel = {};
-		testView.model.attributes.dataSourceUrl = actualUrl;
-		testView.changeUrl();
-		assertDataDetailFieldsReset(testView);
-	});
-	it('expects isValidGridResponse() to return "false" for invalid responses, and "true" for valid responses', function(){
-		var invalidResponses = [
-			undefined,
-			null,
-			false,
-			42,
-			'',
-			'blah',
-			{},
-			{datatypecollection:null},
-			{
-				datatypecollection:
-					{
-
-					}
-			},
-			{
-				datatypecollection:
-					{
-						types : null
-					}
-			},
-			{
-				datatypecollection:
-					{
-						//it should fail on an empty array:
-						types : []
-					}
-			}
-		];
-
-		_.each(invalidResponses, function(invalidResponse){
-			expect(testView.isValidGridResponse(invalidResponse)).toBe(false);
-		});
-
-		var validResponses = [
-			{
-				datatypecollection:
-					{
-						//types may have one object, or a non-zero-length array of objects
-						types : {}
-					}
-			},
-			{
-				datatypecollection:
-					{
-						types : [{}]
-					}
-			},
-						{
-				datatypecollection:
-					{
-						types : [{},{}]
-					}
-			}
-		];
-
-		_.each(validResponses, function(validResponse){
-			expect(testView.isValidGridResponse(validResponse)).toBe(true);
-		});
-	});
-	it('expects the getDateRange() promise to be resolved with no arguments if the web service call succeeds with a parseable response', function(){
-		var starttime = {
-			year: 2001,
-			month: 1,
-			day: 1
-		};
-		var endtime = {
-			year: 2001,
-			month: 1,
-			day: 2
-		};
-		var parseableResponse = {
-			availabletimes: {
-				starttime: starttime,
-				endtime: endtime
-			}
-		};
-
-		var promise,
-		returnedResponse = 'something'; //if successful, this should be set to undefined
-		testView.wps.sendWpsExecuteRequest = resolveWithResponse(parseableResponse);
-		runs(function(){
-			promise = testView.getDateRange('mockUrl', 'mockVariableName').done(function(myResponse){
-				returnedResponse = myResponse;
-			});
-		});
-		waitsFor(function(){
-			return 'pending' !== promise.state();
-		});
-		runs(function(){
-			expect(returnedResponse).toBeUndefined();
-			_.each(testView.dateModelProperties, function(dateModelProperty){
-				expect(testView.model.get(dateModelProperty)).toBeDefined();
-			});
-		});
+		testView.setSelectedVariables(ev);
+		expect(testView.model.get('dataVariables')).toEqual(['var1', 'var2']);
 	});
 });

--- a/src/test/js/specs/DataDetailsView_spec.js
+++ b/src/test/js/specs/DataDetailsView_spec.js
@@ -3,19 +3,32 @@
 describe('GDP.PROCESS_CLIENT.view.DataDetailsView', function() {
 	var model,
 	templateSpy,
-	renderSpy,
 	loggerSpy,
 	server,
 	testView,
 	url,
 	dataSourceModel,
 	dataSourceFetchDeferred,
-	updateDataSetModelDeferred;
+	updateDataSetModelDeferred,
+	preventDefaultSpy
+
+	var $testDiv;
 
 	//no-op alert
 	window.alert = function(){};
 
 	beforeEach(function() {
+		$('body').append('<div id="test-div"></div>');
+		$testDiv = $('#test-div');
+
+		$testDiv.html('<select id="data-source-select"><option></option></select>' +
+			'<input id="data-source-url" type="url" />' +
+			'<input id="use-cached-checkbox" type="checkbox" />' +
+			'<select id="data-source-vars" multiple /></select>' +
+			'<input id="start-date" type="text" />' +
+			'<input id="end-date" type="text" />'
+		);
+
 		url = 'http://testUrl';
 		GDP.config = {
 			get : function(prop) {
@@ -55,17 +68,25 @@ describe('GDP.PROCESS_CLIENT.view.DataDetailsView', function() {
 		dataSourceFetchDeferred = $.Deferred();
 		spyOn(dataSourceModel, 'fetch').andReturn(dataSourceFetchDeferred);
 
-
 		templateSpy = jasmine.createSpy('templateSpy');
-		loggerSpy = jasmine.createSpyObj('logger', ['error']);
+		loggerSpy = jasmine.createSpyObj('logger', ['debug', 'error']);
+		preventDefaultSpy = jasmine.createSpy('preventDefaultSpy');
 
 		GDP.logger = loggerSpy;
 
 		testView = new GDP.PROCESS_CLIENT.view.DataDetailsView({
 			model : model,
 			template : templateSpy,
+			el : '#test-div'
 		});
 		updateDataSetModelDeferred.resolve();
+	});
+
+	afterEach(function() {
+		testView.remove();
+		$testDiv.remove();
+		model.get('dataSourceModel').get('variables').reset();
+		model.clear();
 	});
 
 	it('Expects setUrl() to change the model\'s dataSourceUrl property', function() {
@@ -88,4 +109,139 @@ describe('GDP.PROCESS_CLIENT.view.DataDetailsView', function() {
 		testView.setSelectedVariables(ev);
 		expect(testView.model.get('dataVariables')).toEqual(['var1', 'var2']);
 	});
+
+	it('Expects setStartDate to change the model\'s startDate property', function() {
+		testView.setStartDate({
+			preventDefault : preventDefaultSpy,
+			target : { value : '2/3/2005' }
+		});
+
+		expect(testView.model.get('startDate')).toEqual('2/3/2005');
+	});
+
+	it('Expects setEndDate to change the model\'s endDate property', function() {
+		testView.setEndDate({
+			preventDefault : preventDefaultSpy,
+			target : { value : '11/12/2006' }
+		});
+		expect(testView.model.get('endDate')).toEqual('11/12/2006');
+	});
+
+
+	it('Expects that updating the model\s url property disables all inputs and fetches the data source model', function() {
+		var dataSourceModel = testView.model.get('dataSourceModel');
+		testView.model.set('dataSourceUrl', url);
+
+		expect(testView.$('#data-source-url').is(':disabled')).toBe(true);
+		expect(testView.$('#data-source-select').is(':disabled')).toBe(true);
+		expect(testView.$('#data-source-vars').is(':disabled')).toBe(true);
+		expect(testView.$('#start-date').is(':disabled')).toBe(true);
+		expect(testView.$('#end-date').is(':disabled')).toBe(true);
+
+		expect(dataSourceModel.fetch).toHaveBeenCalledWith({
+			dataSourceUrl : url,
+			allowCached : false
+		});
+
+		$('#use-cached-checkbox').prop('checked', true);
+		testView.model.set('dataSourceUrl', url + '1');
+
+		expect(dataSourceModel.fetch.mostRecentCall.args[0]).toEqual({
+			dataSourceUrl : url + '1',
+			allowCached : true
+		});
+	});
+
+	it('Expects a successful fetch to reenable the inputs', function() {
+		testView.model.set('dataSourceUrl', url);
+		dataSourceFetchDeferred.resolve();
+
+		expect(testView.$('#data-source-url').is(':disabled')).toBe(false);
+		expect(testView.$('#data-source-select').is(':disabled')).toBe(false);
+		expect(testView.$('#data-source-vars').is(':disabled')).toBe(false);
+		expect(testView.$('#start-date').is(':disabled')).toBe(false);
+		expect(testView.$('#end-date').is(':disabled')).toBe(false);
+	});
+
+	it('Expects a failed fetch to reenable the inputs and to clear the dataVariable, startDate, and endDate fields', function() {
+		testView.model.set('dataVariable', ['var1']);
+		testView.model.set('startDate', '2/1/2005');
+		testView.model.set('endDate', '3/1/2005');
+
+		testView.model.set('dataSourceUrl', url);
+		dataSourceFetchDeferred.reject();
+
+		expect(testView.$('#data-source-url').is(':disabled')).toBe(false);
+		expect(testView.$('#data-source-select').is(':disabled')).toBe(false);
+		expect(testView.$('#data-source-vars').is(':disabled')).toBe(false);
+		expect(testView.$('#start-date').is(':disabled')).toBe(false);
+		expect(testView.$('#end-date').is(':disabled')).toBe(false);
+
+		expect(testView.model.get('dataVariable')).toEqual([]);
+		expect(testView.model.get('startDate')).toEqual('');
+		expect(testView.model.get('endDate')).toEqual('');
+	});
+
+	it('Expects that if the variables property in the dataSourceModel are updated, the list of variables is updated', function() {
+		var varPicker = testView.$('#data-source-vars');
+		var dataSourceVariables = new GDP.PROCESS_CLIENT.model.DataSourceVariables();
+		dataSourceVariables.add([
+			{
+				name: 'var1',
+				description : 'Var1',
+				unitsstring : 'u1'
+			}, {
+				name : 'var2',
+				description : 'Var2',
+				unitsstring : 'u2'
+			}
+		]);
+		testView.model.get('dataSourceModel').set('variables', dataSourceVariables);
+
+		expect(varPicker.find('option').length).toBe(2);
+		expect(varPicker.is(':disabled')).toBe(false);
+
+		dataSourceVariables = new GDP.PROCESS_CLIENT.model.DataSourceVariables();
+		testView.model.get('dataSourceModel').set('variables', dataSourceVariables);
+		expect(varPicker.find('option').length).toBe(0);
+		expect(varPicker.is(':disabled')).toBe(true);
+	});
+
+	it('Expects that changing the dateRange in the dataSourceModel sets the values of the start/endDate in the model and sets the disabled state of the date pickers', function() {
+		testView.model.get('dataSourceModel').set('dateRange', {
+			start : '2/1/2005',
+			end : '3/2/2005'
+		});
+
+		expect(testView.model.get('startDate')).toEqual('2/1/2005');
+		expect(testView.model.get('endDate')).toEqual('3/2/2005');
+	});
+
+	it('Expects the variable picker to be updated if the dataVariables property in the model changes', function() {
+		var $variablePicker = testView.$('#data-source-vars');
+		var dataSourceVariables = new GDP.PROCESS_CLIENT.model.DataSourceVariables();
+		dataSourceVariables.add([
+			{
+				name: 'var1',
+				description : 'Var1',
+				unitsstring : 'u1'
+			}, {
+				name : 'var2',
+				description : 'Var2',
+				unitsstring : 'u2'
+			}, {
+				name : 'var3',
+				description : 'Var3',
+				unitsstring : 'u3'
+			}
+		]);
+		testView.model.get('dataSourceModel').set('variables', dataSourceVariables);
+		testView.model.set('dataVariables', ['var1', 'var2']);
+		expect($variablePicker.val()).toEqual(['var1', 'var2']);
+
+		testView.model.set('dataVariables', []);
+		expect($variablePicker.val()).toEqual(null);
+	});
+
+	//Tried to write tests for changeStartDate and changeEndDate but the datepicker did not want to work properly in tests.
 });

--- a/src/test/js/specs/DataSourceModels_spec.js
+++ b/src/test/js/specs/DataSourceModels_spec.js
@@ -1,0 +1,254 @@
+/*jslint browser: true */
+/*global sinon */
+/*global $*/
+/*global jasmine */
+/*global GDP */
+/*global expect */
+
+describe('DataSourceModels', function() {
+
+	var server;
+
+	beforeEach(function() {
+		GDP.config.set('application', {
+			endpoints : {
+				utilityWPS : 'http://fakeUtilityWPS'
+			}
+		});
+		server = sinon.fakeServer.create();
+	});
+
+	afterEach(function() {
+		server.restore();
+	});
+
+	describe('DataSourceVariables collection', function() {
+
+		var wpsDeferred;
+		var testCollection;
+		var successSpy, failedSpy;
+
+		beforeEach(function() {
+			wpsDeferred = $.Deferred();
+
+			GDP.wpsClient = {
+				sendWpsExecuteRequest : jasmine.createSpy().andReturn(wpsDeferred.promise())
+			};
+
+			successSpy = jasmine.createSpy('SuccessSpy');
+			failedSpy = jasmine.createSpy('FailedSpy');
+
+			testCollection = new GDP.PROCESS_CLIENT.model.DataSourceVariables();
+		});
+
+		it('Expects when fetch is called that a properly formated wps request is sent', function() {
+			testCollection.fetch({
+				dataSourceUrl : 'http://fakeDataSource',
+				allowCached : true
+			});
+
+			expect(GDP.wpsClient.sendWpsExecuteRequest).toHaveBeenCalled();
+			expect(GDP.wpsClient.sendWpsExecuteRequest.calls[0].args[2]).toEqual({
+				'catalog-url' : ['http://fakeDataSource'],
+				'allow-cached-response' : ['true']
+			});
+
+			testCollection.fetch({
+				dataSourceUrl : 'http://fakeDataSource',
+				allowCached : false
+			});
+			expect(GDP.wpsClient.sendWpsExecuteRequest.calls.length).toBe(2);
+			expect(GDP.wpsClient.sendWpsExecuteRequest.calls[1].args[2]).toEqual({
+				'catalog-url' : ['http://fakeDataSource'],
+				'allow-cached-response' : ['false']
+			});
+		});
+		it('Expects a successful response to resolve the promise returned by fetch', function() {
+			var response = {
+				datatypecollection : {
+					types : [
+						{
+							name : 'Name1',
+							description : 'Description1',
+							unitsstring : 'Unit1'
+						},{
+							name : 'Name2',
+							description : 'Description2',
+							unitsstring : 'Unit2'
+						},{
+							name : 'Name3',
+							description : 'Description3',
+							unitsstring : 'Unit3'
+						}
+					]
+				}
+			};
+			testCollection.fetch({
+				dataSourceUrl : 'http://fakeDataSource',
+				allowCached : false
+			}).done(successSpy).fail(failedSpy);
+
+			expect(successSpy).not.toHaveBeenCalled();
+			expect(failedSpy).not.toHaveBeenCalled();
+
+			wpsDeferred.resolve(response);
+			expect(successSpy).toHaveBeenCalled();
+			expect(failedSpy).not.toHaveBeenCalled();
+
+			expect(testCollection.models.length).toBe(3);
+			expect(testCollection.models[0].attributes).toEqual(response.datatypecollection.types[0]);
+		});
+
+		it('Expects a successful response with bad data to reject the promise', function() {
+			var response = {
+				t : 1,
+				a : 2
+			};
+
+			testCollection.fetch({
+				dataSourceUrl : 'http://fakeDataSource',
+				allowCached : false
+			}).done(successSpy).fail(failedSpy);
+
+			wpsDeferred.resolve(response);
+			expect(successSpy).not.toHaveBeenCalled();
+			expect(failedSpy).toHaveBeenCalled();
+
+			wpsDeferred = $.Deferred();
+			testCollection.fetch({
+				dataSourceUrl : 'http://fakeDataSource',
+				allowCached : false
+			}).done(successSpy).fail(failedSpy);
+
+			response = {
+				datatypecollection : {
+					t : 1
+				}
+			};
+			wpsDeferred.resolve(response);
+			expect(successSpy).not.toHaveBeenCalled();
+			expect(failedSpy.calls.length).toBe(2);
+		});
+
+		it('Expects a failed response to reject the promise', function() {
+			testCollection.fetch({
+				dataSourceUrl : 'http://fakeDataSource',
+				allowCached : false
+			}).done(successSpy).fail(failedSpy);
+
+			wpsDeferred.reject();
+			expect(successSpy).not.toHaveBeenCalled();
+			expect(failedSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('DataSourceModel tests', function() {
+		var wpsDeferred;
+		var testModel;
+		var successSpy, failedSpy;
+
+		beforeEach(function() {
+			wpsDeferred = $.Deferred();
+			successSpy = jasmine.createSpy('SuccessSpy');
+			failedSpy = jasmine.createSpy('FailedSpy');
+
+			GDP.wpsClient = {
+				sendWpsExecuteRequest : jasmine.createSpy().andReturn(wpsDeferred.promise())
+			};
+
+			testModel = new GDP.PROCESS_CLIENT.model.DataSourceModel();
+		});
+
+		describe('DataSourceModel.getDateRange tests', function() {
+			beforeEach(function() {
+				testModel.set('url', 'http://fakeDataService');
+				testModel.get('variables').add([
+					{
+						name : 'Name1',
+						description : 'Description1',
+						unitsstring : 'Unit1'
+					},{
+						name : 'Name2',
+						description : 'Description2',
+						unitsstring : 'Unit2'
+					},{
+						name : 'Name3',
+						description : 'Description3',
+						unitsstring : 'Unit3'
+					}
+				]);
+			});
+
+			it('Expects a call to getDateRange to setup the wps call properly', function() {
+				testModel.getDateRange({allowCached : true});
+
+				expect(GDP.wpsClient.sendWpsExecuteRequest).toHaveBeenCalled();
+				expect(GDP.wpsClient.sendWpsExecuteRequest.calls[0].args[2]).toEqual({
+					"catalog-url" : ['http://fakeDataService'],
+					'allow-cached-response' : ['true'],
+					'grid' : ['Name1']
+				});
+
+				testModel.getDateRange({allowCached : false});
+				expect(GDP.wpsClient.sendWpsExecuteRequest.calls.length).toBe(2);
+				expect(GDP.wpsClient.sendWpsExecuteRequest.calls[1].args[2]['allow-cached-response']).toEqual(['false']);
+			});
+
+			it('Expects a properly formatted response to update the model and resolve the promise', function() {
+				var response = {
+					availabletimes : {
+						starttime : {
+							year : 2001,
+							month : 12,
+							day : 15
+						},
+						endtime : {
+							year : 2010,
+							month : 2,
+							day : 1
+						}
+					}
+				};
+
+				testModel.getDateRange({allowCached : true }).done(successSpy).fail(failedSpy);
+				expect(successSpy).not.toHaveBeenCalled();
+				expect(failedSpy).not.toHaveBeenCalled();
+
+				wpsDeferred.resolve(response);
+				expect(successSpy).toHaveBeenCalled();
+				expect(failedSpy).not.toHaveBeenCalled();
+
+				expect(testModel.get('dateRange')).toEqual({
+					start : '12/15/2001',
+					end : '2/1/2010'
+				});
+			});
+
+			it('Expects a successful call with improperly formatted response to reject the promise', function() {
+				var response = {
+					a : 1
+				};
+				testModel.getDateRange({allowCached : true }).done(successSpy).fail(failedSpy);
+				wpsDeferred.resolve(response);
+				expect(successSpy).not.toHaveBeenCalled();
+				expect(failedSpy).toHaveBeenCalled();
+
+				var response = {
+					availabletimes : {starttime : 1}
+				};
+				wpsDeferred = $.Deferred();
+				testModel.getDateRange({allowCached : true }).done(successSpy).fail(failedSpy);
+				wpsDeferred.resolve(response);
+				expect(successSpy).not.toHaveBeenCalled();
+				expect(failedSpy.calls.length).toBe(2);
+			});
+
+			it('Expects a failed WPS call to reject the promise', function() {
+				testModel.getDateRange({allowCached : true }).done(successSpy).fail(failedSpy);
+				wpsDeferred.reject('Failed message');
+				expect(successSpy).not.toHaveBeenCalled();
+				expect(failedSpy).toHaveBeenCalled();
+			});
+		});
+	});
+});

--- a/src/test/js/specs/JobModel_spec.js
+++ b/src/test/js/specs/JobModel_spec.js
@@ -201,18 +201,6 @@ describe('GDP.PROCESS_CLIENT.model.Job', function() {
 		expect(jobModel.getProcessInputs()).toBe(null);
 	});
 
-	it('Expects getSelectedDataSourceVariables to return an array of DataSourceVariables for those in jobModel whose selected attribute is true', function() {
-			var var1 = new GDP.PROCESS_CLIENT.model.DataSourceVariable({text : 'Text1', value : 'value1', selected : true});
-			var var2 = new GDP.PROCESS_CLIENT.model.DataSourceVariable({text : 'Text2', value : 'value2', selected : true});
-			var var3 = new GDP.PROCESS_CLIENT.model.DataSourceVariable({text : 'Text3', value : 'value3', selected : false});
-
-			jobModel.get('dataSourceVariables').reset([var1, var2, var3]);
-			var result = jobModel.getSelectedDataSourceVariables();
-			expect(result.length).toBe(2);
-			expect(result).toContain(var1);
-			expect(result).toContain(var2);
-	});
-
 	it('Expects getProcessInputs to return the inputs minus excluded inputs', function() {
 		jobModel.set('algorithmId', 'gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm');
 		var inputs = jobModel.getProcessInputs();
@@ -330,11 +318,7 @@ describe('GDP.PROCESS_CLIENT.model.Job', function() {
 		});
 
 		it('Expects DATASET_ID to be assigned to the values in the selected DataSourceVariables', function() {
-			var var1 = new GDP.PROCESS_CLIENT.model.DataSourceVariable({text : 'Text1', value : 'value1', selected : true});
-			var var2 = new GDP.PROCESS_CLIENT.model.DataSourceVariable({text : 'Text2', value : 'value2', selected : true});
-			var var3 = new GDP.PROCESS_CLIENT.model.DataSourceVariable({text : 'Text3', value : 'value3', selected : false});
-
-			jobModel.get('dataSourceVariables').reset([var1, var2, var3]);
+			jobModel.set('dataVariables',['value1', 'value2']);
 			var result = getWPSStringInputsResult();
 			expect(result.DATASET_ID.length).toBe(2);
 			expect(result.DATASET_ID).toContain('value1');


### PR DESCRIPTION
Refactored the DataDetailsView to move the fetching of the data variables and min/max Dates into DataSourceModels. The models were also reworked so that the model represented the data received. The view is then responsible for putting the data into a form that can be used by SelectMenuView.

The views no longer depend on wps as this is used in the models to fetch the data. I made this a namespaced global, GDP.wpsClient  similar to what we do with GDP.cswClient.

As part of this refactor, made the data details inputs disabled while the data source model is being fetched.