### PR TITLE
Re - defaulting variable cache use and removing the auto-select if only one dataset. 

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/algorithms.json
+++ b/src/main/webapp/WEB-INF/jsp/algorithms.json
@@ -156,6 +156,16 @@
             "gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm", 
             "gov.usgs.cida.gdp.wps.algorithm.FeatureGridStatisticsAlgorithm", 
             "gov.usgs.cida.gdp.wps.algorithm.FeatureCoverageOPeNDAPIntersectionAlgorithm"
+        ],
+        "5752f2d9e4b053f0edd15628": [
+            "gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm", 
+            "gov.usgs.cida.gdp.wps.algorithm.FeatureGridStatisticsAlgorithm", 
+            "gov.usgs.cida.gdp.wps.algorithm.FeatureCoverageOPeNDAPIntersectionAlgorithm"
+        ],
+        "5752f393e4b053f0edd1562d": [
+            "gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm", 
+            "gov.usgs.cida.gdp.wps.algorithm.FeatureGridStatisticsAlgorithm", 
+            "gov.usgs.cida.gdp.wps.algorithm.FeatureCoverageOPeNDAPIntersectionAlgorithm"
         ]
     }
 }

--- a/src/main/webapp/js/process_client/models/JobModel.js
+++ b/src/main/webapp/js/process_client/models/JobModel.js
@@ -82,10 +82,6 @@ var GDP = GDP || {};
 						if (response.records.length > 0){
 							dataSetModel.clear();
 							dataSetModel.set(dataSetModel.parse(response.records[0]));
-							if (dataSetModel.get('dataSources').length === 1) {
-								// auto assign the dataSourceUrl property if only one data source in the data set.
-								self.set('dataSourceUrl', dataSetModel.get('dataSources')[0].url);
-							}
 							deferred.resolve();
 						}
 						else {

--- a/src/main/webapp/templates/datadetail.html
+++ b/src/main/webapp/templates/datadetail.html
@@ -15,7 +15,7 @@
 		</div>
 		<div class="checkbox">
 			<label>
-				<input id="use-cached-checkbox" type="checkbox">Use cached variables and time range. Uncheck for datasets that update frequently.
+				<input id="use-cached-checkbox" type="checkbox" checked>Use cached variables and time range. Uncheck for datasets that update frequently.
 			</label>
 		</div>
 		<div class="form-group">


### PR DESCRIPTION
This is a reasonable solution to the problem with controlling the use of the cache. We may want to revisit this workflow so it's more intuitive and easy in the future, but this works well for now.