### PR TITLE
Gdp 1082

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 		<dependency>
 			<groupId>gov.usgs.cida.jslibs</groupId>
 			<artifactId>usgs-template</artifactId>
-			<version>2.3</version>
+			<version>2.5</version>
 			<type>war</type>
 		</dependency>
 			

--- a/src/main/webapp/js/process_client/models/JobModel.js
+++ b/src/main/webapp/js/process_client/models/JobModel.js
@@ -129,8 +129,8 @@ var GDP = GDP || {};
 
 				if (uri.protocol === '') {
 					// initially assume http
-					dataSourceUrl = dataSourceUrl.replace(/^/, 'http://');
-					uri.protocol = 'http';
+					dataSourceUrl = dataSourceUrl.replace(/^/, 'https://');
+					uri.protocol = 'https';
 				}
 
 				// TODO: need a cleaner way of testing service type and failing over

--- a/src/main/webapp/js/util/mapUtils.js
+++ b/src/main/webapp/js/util/mapUtils.js
@@ -29,7 +29,7 @@ GDP.util.mapUtils = (function() {
 	that.createWorldStreetMapLayer = function() {
 		return new OpenLayers.Layer.XYZ(
 			"World Street Map",
-			"http://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map" + zyx,
+			"https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map" + zyx,
 			{
 				isBaseLayer: true,
 				units: "m",


### PR DESCRIPTION
Locally, I've made a few small code changes and a single configuration change (updating gdp base url in context.xml). Most things are looking good. There are a few errors that I don't think I can correct from the ui. For example, I can successfully process the dataset with id:
54dd5e05e4b08de9379b38e1
But some errors are logged in dev tools:
```
jquery.js:8625 Mixed Content: The page at 'https://localhost:8449/gdp_web/client/#!catalog/gdp/dataset/54dd5e05e4b08de9379b38e1' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://cida.usgs.gov/thredds/dodsC/prism_v2?request=GetCapabilities&version=1.1.1'. This request has been blocked; the content must be served over HTTPS.send @ jquery.js:8625ajax @ jquery.js:8161getWCSDataSourceUrl @ JobModel.js:140getWPSStringInputs @ JobModel.js:204submitProcessingRequest @ HubView.js:143dispatch @ jquery.js:4430elemData.handle @ jquery.js:4116

jquery.js:8625 XMLHttpRequest cannot load http://cida.usgs.gov/thredds/dodsC/prism_v2?request=GetCapabilities&version=1.1.1. Failed to start loading.send @ jquery.js:8625ajax @ jquery.js:8161getWCSDataSourceUrl @ JobModel.js:140getWPSStringInputs @ JobModel.js:204submitProcessingRequest @ HubView.js:143dispatch @ jquery.js:4430elemData.handle @ jquery.js:4116
```
The processing still completes successfully. I still receive an email with the results and can download the input and output on demand.

I don't think the errors can be addressed in the app's code. I believe this can be solved by updating the metadata for the datasets so that they point at https. Do you agree?